### PR TITLE
POST formdata to create torrents (including mutable ones)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Testing
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        node: [ '12', '14', '16' ]
+    name: Node ${{ matrix.node }} sample
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - run: npm run lint
+      - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Testing
 
-on: [ push, pull_request ]
+on: [ pull_request ]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,18 +3,21 @@ name: Testing
 on: [ push, pull_request ]
 
 jobs:
-  build:
-    runs-on: ubuntu-16.04
+  test:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node: [ '12', '14', '16' ]
-    name: Node ${{ matrix.node }} sample
+        include:
+          - os: ubuntu-latest
+          - os: windows-latest
+          - os: macos-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '16'
       - run: npm install
       - run: npm run lint
       - run: npm test

--- a/index.js
+++ b/index.js
@@ -52,9 +52,9 @@ module.exports = function makeBTFetch (opts = {}) {
     const mainMethod = method
     const mainReq = headers.accept && headers.accept.includes('text/html')
     const mainRes = mainReq ? 'text/html; charset=utf-8' : 'application/json; charset=utf-8'
-    const mainUpdate = search.get('update')
+    let mainUpdate = search.get('update')
     mainUpdate = mainUpdate ? JSON.parse(mainUpdate) : null
-    const mainRemove = search.get('remove')
+    let mainRemove = search.get('remove')
     mainRemove = mainRemove ? JSON.parse(mainRemove) : null
     const mainRange = headers.Range || headers.range
     return { mainQuery, mainHost, mainPath, mainMethod, mainReq, mainRes, mainType, mainUpdate, mainRemove, mainRange }

--- a/index.js
+++ b/index.js
@@ -98,9 +98,9 @@ module.exports = function makeBTFetch(opts = {}){
                             checkCode = 400
                         } else {
                             if(req.mainReq){
-                                mainData = ['<html><head><title>Config</title></head><body><div><p>timeout: ' + app._status.timeout + '</p><p>Torrents: ' + app.webtorrent.torrents.length + '</p><p>initial: ' + app._status.initial + '</p><p>current: ' + app._status.current + '</p><p>share: ' + app._status.share + '</p><div></body></html>']
+                                mainData = ['<html><head><title>Config</title></head><body><div><p>timeout: ' + app._status.timeout + '</p><p>Torrents: ' + app.webtorrent.torrents.length + '</p><p>initial: ' + app._status.initial + '</p><p>current: ' + app._status.current + '</p><p>share: ' + app._status.share + '</p><p>clear: ' + app._status.clear + '</p><div></body></html>']
                             } else {
-                                mainData = [JSON.stringify({timeout: app._timeOut, share: app._status.share, current: app._status.current, initial: app._status.initial, torrents: app.webtorrent.torrents.length})]
+                                mainData = [JSON.stringify({timeout: app._timeOut, share: app._status.share, current: app._status.current, initial: app._status.initial, clear: app._status.clear, torrents: app.webtorrent.torrents.length})]
                             }
                             checkCode = 200
                         }

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function makeBTFetch (opts = {}) {
       const isHEAD = method === 'HEAD'
       const isWebframe = reqHeaders.accept && reqHeaders.accept.includes('text/html')
       const isFormData = reqHeaders['content-type'] && reqHeaders['content-type'].includes('multipart/form-data')
-      const isPetname = PETNAME_REGEX.test(hostname)
+      const isPetname = !isInfohash && !isPublicKey && !isSpecialHostname && PETNAME_REGEX.test(hostname)
       // Domains must have at least one `.` to differentiate them from petnames
       // This will come in handy once we get DNSLink working
       // const isDomain = !isPetname && DOMAIN_REGEX.test(hostname)

--- a/index.js
+++ b/index.js
@@ -206,6 +206,9 @@ module.exports = function makeBTFetch (opts = {}) {
             } else if(req.mainUpdate === null){
               res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>url param "update" is required</p></div></body></html>'] : [JSON.stringify('url param "update" is required')]
               res.statusCode = 400
+            } else if(!reqHeaders['Content-Type'] || !reqHeaders['Content-Type'].includes('multipart/form-data;')){
+              res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>Content-Type header is invalud</p></div></body></html>'] : [JSON.stringify('Content-Type header is invalid')]
+              res.statusCode = 400
             } else {
               if(req.mainUpdate === true){
                 const { torrent, secret } = await app.publishAddress(null, reqHeaders, body)
@@ -226,6 +229,9 @@ module.exports = function makeBTFetch (opts = {}) {
                 prog.delete(req.mainQuery)
               }
               res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>body is required</p></div></body></html>'] : [JSON.stringify('body is required')]
+              res.statusCode = 400
+            } else if(!reqHeaders['Content-Type'] || !reqHeaders['Content-Type'].includes('multipart/form-data;')){
+              res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>Content-Type header is invalud</p></div></body></html>'] : [JSON.stringify('Content-Type header is invalid')]
               res.statusCode = 400
             } else {
               if(prog.has(req.mainQuery)){

--- a/index.js
+++ b/index.js
@@ -107,9 +107,9 @@ module.exports = function makeBTFetch(opts = {}){
                             if(req.mainPath === path.sep){
                                 if(req.mainReq){
                                     if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
-                                        res.data = [`<html><head><title>${tempData.name}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
+                                        res.data = [`<html><head><title>${tempData.address}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                     } else {
-                                        res.data = [`<html><head><title>${tempData.name}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
+                                        res.data = [`<html><head><title>${tempData.address}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                     }
                                 } else {
                                     if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
@@ -160,9 +160,9 @@ module.exports = function makeBTFetch(opts = {}){
                             if(req.mainPath === path.sep){
                                 if(req.mainReq){
                                     if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
-                                        res.data = [`<html><head><title>${tempData.name}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
+                                        res.data = [`<html><head><title>${tempData.infoHash}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                     } else {
-                                        res.data = [`<html><head><title>${tempData.name}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
+                                        res.data = [`<html><head><title>${tempData.infoHash}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                     }
                                 } else {
                                     if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const makeFetch = require('make-fetch')
 const path = require('path')
-const BTFetchTorrent = require('bt-fetch-torrent')
+const Main = require('./main.js')
 const streamToIterator = require('stream-async-iterator')
 const mime = require('mime/lite')
 const parseRange = require('range-parser')
@@ -11,7 +11,7 @@ const checkTitle = new RegExp('^[a-f0-9]{32}$')
 const DEFAULT_OPTS = {
     folder: __dirname,
     storage: 'storage',
-    files: 'magnet',
+    author: 'author',
 }
 
 module.exports = function makeBTFetch(opts = {}){
@@ -21,7 +21,7 @@ module.exports = function makeBTFetch(opts = {}){
     // const sideType = '-'
     const hostType = '_'
 
-    const app = new BTFetchTorrent({folder: finalOpts.folder, storage: finalOpts.storage, files: finalOpts.files})
+    const app = new Main({folder: finalOpts.folder, storage: finalOpts.storage, author: finalOpts.author})
 
     const prog = new Map()
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function makeBTFetch (opts = {}) {
   const torrents = new TorrentManager(finalOpts)
 
   const fetch = makeFetch(async ({ url, method, headers: reqHeaders, body }) => {
-    const { hostname, pathname, protocol, searchParams } = new URL(url)
+    const { hostname, pathname, protocol } = new URL(url)
     const headers = {
       'Content-Type': 'text/plain; charset=utf-8'
     }
@@ -113,6 +113,21 @@ module.exports = function makeBTFetch (opts = {}) {
               const notFoundError = new Error('Not found')
               notFoundError.statusCode = 404
               throw notFoundError
+            }
+
+            if (isWebframe) {
+              const indexPage = `
+<!DOCTYPE html>
+<title>${url}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<h1>Index of ${pathname}</h1>
+<ul>
+  <li><a href="../">../</a></li>${files.map((file) => `
+  <li><a href="${file}">./${file}</a></li>
+`).join('')}
+</ul>
+`
+              return formatHTML(200, indexPage)
             }
 
             return formatJSON(200, files)

--- a/index.js
+++ b/index.js
@@ -1,311 +1,215 @@
 const makeFetch = require('make-fetch')
-const path = require('path')
-const Main = require('./main.js')
+const TorrentManager = require('./torrent-manager.js')
 const streamToIterator = require('stream-async-iterator')
 const mime = require('mime/lite')
 const parseRange = require('range-parser')
 
-const checkHash = new RegExp('^[a-fA-F0-9]{40}$')
-const checkAddress = new RegExp('^[a-fA-F0-9]{64}$')
+const HASH_REGEX = /^[a-fA-F0-9]{40}$/
+const ADDRESS_REGEX = /^[a-fA-F0-9]{64}$/
+const PETNAME_REGEX = /^(?:-|[a-zA-Z0-9]|_)+$/
+const DOMAIN_REGEX = /^(?:-|[a-zA-Z0-9]|\.)+$/
+const META_HOSTNAME = '$'
 const DEFAULT_OPTS = {
   folder: __dirname,
   storage: 'storage',
   author: 'author'
 }
 
+const SUPPORTED_METHODS = ['GET', 'POST', 'DELETE', 'HEAD']
+
 module.exports = function makeBTFetch (opts = {}) {
   const finalOpts = { ...DEFAULT_OPTS, ...opts }
 
-  const SUPPORTED_METHODS = ['GET', 'POST', 'DELETE', 'HEAD']
-  // const sideType = '-'
-  const hostType = '_'
+  const torrents = new TorrentManager(finalOpts)
 
-  const app = new Main(finalOpts)
-
-  const prog = new Map()
-
-  async function getBody (body) {
-    let mainData = ''
-
-    for await (const data of body) {
-      mainData += data
+  const fetch = makeFetch(async ({ url, method, headers: reqHeaders, body }) => {
+    const { hostname, pathname, protocol, searchParams } = new URL(url)
+    const headers = {
+      'Content-Type': 'text/plain; charset=utf-8'
     }
-
-    return mainData
-  }
-
-  function getMimeType (path) {
-    let mimeType = mime.getType(path) || 'text/plain'
-    if (mimeType.startsWith('text/')) mimeType = `${mimeType}; charset=utf-8`
-    return mimeType
-  }
-
-  function formatReq (hostname, pathname, method, search, headers) {
-    // let mainType = hostname[0] === hostType || hostname[0] === sideType ? hostname[0] : ''
-    const mainType = hostname[0] === hostType
-    const mainQuery = mainType ? hostname.replace(hostname[0], '') : hostname
-    const mainHost = hostname
-    // if(pathname){
-    //     console.log(decodeURIComponent(pathname))
-    // }
-    const mainPath = pathname ? decodeURIComponent(pathname).replace(/\//g, path.sep) : path.sep
-    const mainMethod = method
-    const mainReq = headers.accept && headers.accept.includes('text/html')
-    const mainRes = mainReq ? 'text/html; charset=utf-8' : 'application/json; charset=utf-8'
-    let mainUpdate = search.get('update')
-    mainUpdate = mainUpdate ? JSON.parse(mainUpdate) : null
-    let mainRemove = search.get('remove')
-    mainRemove = mainRemove ? JSON.parse(mainRemove) : null
-    const mainRange = headers.Range || headers.range
-    return { mainQuery, mainHost, mainPath, mainMethod, mainReq, mainRes, mainType, mainUpdate, mainRemove, mainRange }
-  }
-
-  const fetch = makeFetch(async request => {
-    // if (request.body !== null) {
-    //   request.body = await getBody(request.body)
-    //   try {
-    //     request.body = JSON.parse(request.body)
-    //   } catch (error) {
-    //     console.log(error)
-    //   }
-    // }
-
-    const { url, method, headers: reqHeaders, body } = request
-
     try {
-      const { hostname, pathname, protocol, searchParams } = new URL(url)
+      const isInfohash = hostname.length === 40 && HASH_REGEX.test(hostname)
+      const isPublicKey = hostname.length === 64 && ADDRESS_REGEX.test(hostname)
+      const isSpecialHostname = hostname === META_HOSTNAME
+      const isHEAD = method === 'HEAD'
+      const isWebframe = reqHeaders.accept && reqHeaders.accept.includes('text/html')
+      const isFormData = reqHeaders['content-type'] && reqHeaders['content-type'].includes('multipart/form-data')
+      const isPetname = PETNAME_REGEX.test(hostname)
+      // Domains must have at least one `.` to differentiate them from petnames
+      const isDomain = !isPetname && DOMAIN_REGEX.test(hostname)
+
+      function formatResponse (statusCode, responseData = '') {
+        const data = [responseData]
+        return {
+          statusCode,
+          headers,
+          data
+        }
+      }
+
+      function formatJSON (statusCode, json = {}) {
+        headers['Content-Type'] = 'application/json; charset=utf-8'
+        return formatResponse(statusCode, JSON.stringify(json, null, '\t'))
+      }
+
+      function formatHTML (statusCode, html = '') {
+        headers['Content-Type'] = 'text/html; charset=utf-8'
+        return formatResponse(statusCode, html)
+      }
 
       if (protocol !== 'bittorrent:') {
-        return {statusCode: 409, headers: {}, data: ['wrong protocol']}
-      } else if(!method || !SUPPORTED_METHODS.includes(method)){
-        return {statusCode: 409, headers: {}, data: ['something wrong with method']}
-      } else if((!hostname) || (hostname.length !== 1 && hostname.length !== 32 && hostname.length !== 40 && hostname.length !== 64) || (hostname.length === 1 && hostname !== hostType) || (hostname.length !== 1 && !checkHash.test(hostname) && !checkAddress.test(hostname))){
-        return {statusCode: 409, headers: {}, data: ['something wrong with hostname']}
+        return formatResponse(409, 'wrong protocol')
+      } else if (!method || !SUPPORTED_METHODS.includes(method)) {
+        return formatResponse(409, 'something wrong with method')
+      } else if (!hostname && !isSpecialHostname && !isInfohash && !isPublicKey) {
+        return formatResponse(409, 'Hostname must be an infohash, a public key, or the $ folder')
       }
 
-      const req = formatReq(hostname, pathname, method, searchParams, reqHeaders)
+      // TODO handle isDomain
 
-      const res = { statusCode: 400, headers: {}, data: [] }
-      switch (req.mainMethod) {
-        case 'HEAD': {
-          if (req.mainType) {
-            res.statusCode = 400
-            res.headers['Content-Length'] = 0
-          } else {
-            if (prog.has(req.mainQuery)) {
-              const torrentData = prog.get(req.mainQuery)
-              if (req.mainPath === path.sep) {
-                res.headers['Content-Type'] = req.mainRes
-                res.headers['Content-Length'] = `${torrentData.length}`
-                res.headers['Accept-Ranges'] = 'bytes'
-                res.headers['X-Downloaded'] = `${torrentData.downloaded}`
-                res.statusCode = 200
+      const rangeHeader = reqHeaders.Range || reqHeaders.range
+
+      if ((method === 'GET') || isHEAD) {
+        if (isSpecialHostname) {
+          if (isHEAD) return formatResponse(200)
+          // TODO: List active torrents?
+          return formatResponse(200, isWebframe ? '' : 'Thank you for using BT-Fetch')
+        } else {
+          const torrent = await torrents.resolveTorrent(hostname)
+          const canonical = `bittorrent://${torrent.infoHash}${pathname || '/'}`
+          headers.Link = `<${canonical}>; rel="canonical"`
+
+          const foundFile = findFile(torrent, pathname)
+          if (foundFile) {
+            headers['Content-Type'] = getMimeType(pathname)
+            headers['Content-Length'] = foundFile.length
+            if (rangeHeader) {
+              const ranges = parseRange(foundFile.length, rangeHeader)
+              if (ranges && ranges.length && ranges.type === 'bytes') {
+                const [{ start, end }] = ranges
+                const length = (end - start + 1)
+
+                headers['Content-Length'] = `${length}`
+                headers['Content-Range'] = `bytes ${start}-${end}/${foundFile.length}`
+
+                const data = isHEAD ? [] : streamToIterator(foundFile.createReadStream({ start, end }))
+                return { statusCode: 206, headers, data }
               } else {
-                let tempPath = null
-                if (torrentData.files.length === 1 && torrentData.name === torrentData.files[0].name) {
-                  tempPath = torrentData.path + path.sep
-                } else {
-                  tempPath = torrentData.path + path.sep + torrentData.name + path.sep
-                }
-                const foundFile = torrentData.files.find(file => { return path.sep + file.path.replace(tempPath, '') === req.mainPath })
-                if (foundFile) {
-                  res.headers['Content-Type'] = getMimeType(req.mainPath)
-                  res.headers['Content-Length'] = `${foundFile.length}`
-                  res.headers['Accept-Ranges'] = 'bytes'
-                  res.headers['X-Downloaded'] = `${foundFile.downloaded}`
-                  res.statusCode = 200
-                } else {
-                  res.statusCode = 404
-                  res.headers['Content-Length'] = 0
-                }
+                const data = isHEAD ? [] : streamToIterator(foundFile.createReadStream())
+                return { statusCode: 200, headers, data }
               }
             } else {
-              res.statusCode = 400
-              res.headers['Content-Length'] = 0
+              const data = isHEAD ? [] : streamToIterator(foundFile.createReadStream())
+              return { statusCode: 200, headers, data }
             }
-          }
-          break
-        }
-
-        case 'GET': {
-          if (req.mainType) {
-            res.data = req.mainReq ? ['Thank you for using BT-Fetch'] : [JSON.stringify('Thank you for using BT-Fetch')]
-            res.statusCode = 200
-            res.headers['Content-Type'] = req.mainRes
           } else {
-            let torrentData = null
-            let foundFile = null
-            let tempPath = null
-            if (prog.has(req.mainQuery)) {
-              torrentData = prog.get(req.mainQuery)
-            } else {
-              if (req.mainQuery.length === 64){
-                try {
-                  torrentData = await app.currentAddress(req.mainQuery)
-                } catch (error) {
-                  console.log(error)
-                }
-                if(!torrentData){
-                  torrentData = await app.loadAddress(req.mainQuery)
-                }
-                prog.set(torrentData.address, torrentData)
-              } else if (req.mainQuery.length === 40){
-                try {
-                  torrentData = await app.currentHash(req.mainQuery)
-                } catch (error) {
-                  console.log(error)
-                }
-                if(!torrentData){
-                  torrentData = await app.loadHash(req.mainQuery)
-                }
-                prog.set(torrentData.hash, torrentData)
-              }
+            // Try finding files in directory
+            // TODO: Resolve index files
+            const directoryPath = pathname.endsWith('/') ? pathname : (pathname + '/')
+            const files = findDirectoryFiles(torrent, directoryPath)
+            // If no files are found that means the directory doesn't exist
+            if (!files.length) {
+              const notFoundError = new Error('Not found')
+              notFoundError.statusCode = 404
+              throw notFoundError
             }
-            tempPath = torrentData.files.length === 1 && torrentData.name === torrentData.files[0].name ? torrentData.path + path.sep : torrentData.path + path.sep + torrentData.name + path.sep
-            if (req.mainPath === path.sep) {
-              res.data = req.mainReq ? [`<html><head><title>${torrentData.infoHash}</title></head><body><div>${torrentData.files.map(file => { return `<p><a href="/${file.path.replace(tempPath, '').split(path.sep).map(data => { return encodeURIComponent(data) }).join('/')}">${file.name}</a></p>` })}</div></body></html>`] : [JSON.stringify(torrentData.files.map(file => { return `/${file.path.replace(tempPath, '').split(path.sep).map(data => { return encodeURIComponent(data) }).join('/')}` }))]
-              res.statusCode = 200
-              res.headers['Content-Type'] = req.mainRes
-              res.headers['Content-Length'] = torrentData.length
-            } else {
-              foundFile = torrentData.files.find(file => { return path.sep + file.path.replace(tempPath, '') === req.mainPath })
-              if (foundFile) {
-                if (req.mainRange) {
-                  const ranges = parseRange(foundFile.length, req.mainRange)
-                  if (ranges && ranges.length && ranges.type === 'bytes') {
-                    const [{ start, end }] = ranges
-                    const length = (end - start + 1)
 
-                    res.data = streamToIterator(foundFile.createReadStream({start, end}))
-                    res.headers['Content-Length'] = `${length}`
-                    res.headers['Content-Range'] = `bytes ${start}-${end}/${foundFile.length}`
-                  }
-                  res.statusCode = 206
-                  res.headers['Content-Type'] = getMimeType(req.mainPath)
-                } else {
-                  res.data = streamToIterator(foundFile.createReadStream())
-                  res.headers['Content-Type'] = getMimeType(req.mainPath)
-                  res.headers['Content-Length'] = foundFile.length
-                  res.statusCode = 200
-                }
-              } else {
-                res.data = [JSON.stringify('file was not found')]
-                res.statusCode = 404
-                res.headers['Content-Type'] = 'application/json; charset=utf-8'
-              }
-            }
+            return formatJSON(200, files)
           }
-          break
         }
-
-        case 'POST': {
-          if (req.mainType) {
-            if (!body) {
-              res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>body is required</p></div></body></html>'] : [JSON.stringify('body is required')]
-              res.statusCode = 400
-            } else if(!reqHeaders['content-type'] || !reqHeaders['content-type'].includes('multipart/form-data')){
-              res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>Content-Type header is invalud</p></div></body></html>'] : [JSON.stringify('Content-Type header is invalid')]
-              res.statusCode = 400
-            } else if(req.mainUpdate === null){
-              res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>url param "update" is required</p></div></body></html>'] : [JSON.stringify('url param "update" is required')]
-              res.statusCode = 400
-            } else if(req.mainUpdate === true){
-                const { torrent, secret } = await app.publishAddress(null, reqHeaders, body)
-                prog.set(torrent.address, torrent)
-                res.data = req.mainReq ? [`<html><head><title>${torrent.address}</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p><p>sequence: ${torrent.sequence}</p><p>signature: ${torrent.sig}</p><p>magnet: ${torrent.magnet}</p><p>secret: ${secret}</p></div></body></html>`] : [JSON.stringify({ address: torrent.address, infohash: torrent.infoHash, sequence: torrent.sequence, magnet: torrent.magnet, signature: torrent.sig, secret })]
-                res.statusCode = 200
-            } else if(req.mainUpdate === false){
-                const { torrent, hash } = await app.publishHash(null, reqHeaders, body)
-                prog.set(torrent.hash, torrent)
-                res.data = req.mainReq ? [`<html><head><title>${torrent.hash}</title></head><body><div><p>infohash: ${torrent.infoHash}</p><p>folder: ${hash}</p></div></body></html>`] : [JSON.stringify({ infohash: torrent.infoHash, hash })]
-                res.statusCode = 200
-            }
-            res.headers['Content-Type'] = req.mainRes
-          } else {
-            if(!body){
-              res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>body is required</p></div></body></html>'] : [JSON.stringify('body is required')]
-              res.statusCode = 400
-            } else if(!reqHeaders['content-type'] || !reqHeaders['content-type'].includes('multipart/form-data')){
-              res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>Content-Type header is invalud</p></div></body></html>'] : [JSON.stringify('Content-Type header is invalid')]
-              res.statusCode = 400
-            } else {
-              if(req.mainQuery.length === 64){
-                if(!reqHeaders['authorization']){
-                  res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>secret key is required in the Authorizatiion header</p></div></body></html>'] : [JSON.stringify('secret key is needed inside the Authorization header')]
-                  res.statusCode = 400
-                } else {
-                  if(prog.has(req.mainQuery)){
-                    prog.delete(req.mainQuery)
-                  }
-                  const { torrent, secret } = await app.publishAddress({address: req.mainQuery, secret: reqHeaders['authorization']}, reqHeaders, body)
-                  prog.set(torrent.address, torrent)
-                  res.data = req.mainReq ? [`<html><head><title>${torrent.address}</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p><p>sequence: ${torrent.sequence}</p><p>signature: ${torrent.sig}</p><p>magnet: ${torrent.magnet}</p><p>secret: ${secret}</p></div></body></html>`] : [JSON.stringify({ address: torrent.address, infohash: torrent.infoHash, sequence: torrent.sequence, magnet: torrent.magnet, signature: torrent.sig, secret })]
-                  res.statusCode = 200
-                }
-              } else if(req.mainQuery.length === 40){
-                if(prog.has(req.mainQuery)){
-                  prog.delete(req.mainQuery)
-                }
-                const { torrent, hash } = await app.publishHash(req.mainQuery, reqHeaders, body)
-                prog.set(torrent.hash, torrent)
-                res.data = req.mainReq ? [`<html><head><title>${torrent.hash}</title></head><body><div><p>infohash: ${torrent.infoHash}</p><p>folder: ${hash}</p></div></body></html>`] : [JSON.stringify({ infohash: torrent.hash, hash })]
-                res.statusCode = 200
-              }
-            }
-            res.headers['Content-Type'] = req.mainRes
+      } else if (method === 'POST') {
+        if (isSpecialHostname) {
+          if (!body) throw new Error('Must specify body for uploads')
+          if (!isFormData) {
+            throw new Error('Must specify multipart/form-data in body')
           }
-          break
-        }
-
-        case 'DELETE': {
-          if (req.mainType) {
-            if(req.mainQuery){
-              res.data = req.mainReq ? ['can not have underscore'] : [JSON.stringify('can not have underscore')]
-              res.statusCode = 400
-            } else {
-              res.data = req.mainReq ? ['must have hash or address'] : [JSON.stringify('must have hash or address')]
-              res.statusCode = 400
-            }
-            res.headers['Content-Type'] = req.mainRes
-          } else {
-            if(req.mainRemove === null){
-              res.data = req.mainReq ? [`<html><head><title>BT-Fetch</title></head><body><div><p>url param "remove" is required</p></div></body></html>`] : [JSON.stringify('url param "remove" is required')]
-              res.statusCode = 400
-            } else {
-              if(prog.has(req.mainQuery)) {
-                prog.delete(req.mainQuery)
-              }
-              if (req.mainQuery.length === 64) {
-                res.data = req.mainReq ? [`<html><head><title>${req.mainQuery}</title></head><body><div><p>${req.mainRemove ? await app.removeAddress(req.mainQuery) : app.stopAddress(req.mainQuery)}</p></div></body></html>`] : [JSON.stringify(req.mainRemove ? await app.removeAddress(req.mainQuery) : app.stopAddress(req.mainQuery))]
-                res.statusCode = 200
-              } else if (req.mainQuery.length === 40) {
-                res.data = req.mainReq ? [`<html><head><title>${req.mainQuery}</title></head><body><div><p>${req.mainRemove ? await app.removeHash(req.mainQuery) : app.stopHash(req.mainQuery)}</p></div></body></html>`] : [JSON.stringify(req.mainRemove ? await app.removeHash(req.mainQuery) : app.stopHash(req.mainQuery))]
-                res.statusCode = 200
-              }
-            }
-            res.headers['Content-Type'] = req.mainRes
+          const torrent = await torrents.publishHash(reqHeaders, body)
+          return formatResponse(200, `bittorrent://${torrent.infoHash}/`)
+        } else {
+          if (!isFormData) {
+            throw new Error('Must specify multipart/form-data in body')
           }
-          break
+          if (isInfohash) {
+            throw new Error('Cannot update immutable torrents')
+          }
+          /*
+          // TODO: Support publishing to public key
+          if (isPublicKey && !reqHeaders.authorization) {
+            throw new Error('Must specify secret key in the `authorization` field')
+          }
+          let publicKey = hostname
+          let secret = reqHeaders.authorization
+          let name = hostname
+          if (searchParams.has('title')) {
+            name = searchParams.get('title')
+          }
+          */
+          if (!isPetname) {
+            throw new Error('Public keys not supported yet')
+          }
+          const { publicKey, secretKey } = torrents.createKeypair(hostname)
+          const torrent = await torrents.publishPublicKey(publicKey, secretKey, reqHeaders, body, hostname)
+          return formatResponse(200, `bittorrent://${torrent.publicKey}/`)
         }
+      } else if (method === 'DELETE') {
+        if (isSpecialHostname) {
+          throw new Error('Must specify address')
+        } else {
+          await torrents.deleteTorrent(hostname)
+          return formatResponse(200, 'OK')
+        }
+      } else {
+        return formatResponse(409, 'Method not allowed')
       }
-      return res
     } catch (e) {
-      return { statusCode: 500, headers: {}, data: [e.stack] }
+      console.error(e.stack)
+      const statusCode = e.statusCode ? e.statusCode : 500
+      return { statusCode, headers, data: [e.stack] }
     }
   })
 
   fetch.destroy = () => {
     return new Promise((resolve, reject) => {
-      clearInterval(app.updateRoutine)
-      app.webtorrent.destroy(error => {
+      clearInterval(torrents.updateRoutine)
+      torrents.webtorrent.destroy(error => {
         if (error) {
           reject(error)
         } else {
-          app.webproperty.clearData().then(res => { resolve(res) }).catch(error => { reject(error) })
+          resolve()
         }
       })
     })
   }
 
   return fetch
+}
+
+function findFile (torrent, filePath) {
+  return torrent.files.find(({ relativePath }) => relativePath === filePath)
+}
+
+function findDirectoryFiles (torrent, directoryPath) {
+  return torrent.files
+    .filter(({ path }) => path.startsWith(directoryPath))
+    .map(({ relativePath }) => relativePath.slice(directoryPath.length))
+    .reduce((final, file) => {
+      const segments = file.split('/')
+      // TODO: Concat is probably slow as hell
+      // If the file is directly within this path, add it to the list
+      if (segments.length === 1) return final.concat(file)
+
+      // We've got a file that's in a subfolder of some length
+      // We only want to list a folder that's directly within the path
+      const subpath = segments[0] + '/'
+
+      // If we've already seen a path in this subfolder, ignore this file
+      if (final.includes(subpath)) return final
+      return final.concat(subpath)
+    }, [])
+}
+
+function getMimeType (path) {
+  let mimeType = mime.getType(path) || 'text/plain'
+  if (mimeType.startsWith('text/')) mimeType = `${mimeType}; charset=utf-8`
+  return mimeType
 }

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = function makeBTFetch(opts = {}){
                                 tempData = prog.get(req.mainQuery)
                             } else {
                                 tempData = await app.loadAddress(req.mainQuery)
-                                prog.set(req.mainQuery, tempData)
+                                prog.set(tempData.address, tempData)
                             }
                             if(req.mainPath === path.sep){
                                 if(req.mainReq){
@@ -155,7 +155,7 @@ module.exports = function makeBTFetch(opts = {}){
                                 tempData = prog.get(req.mainQuery)
                             } else {
                                 tempData = await app.loadHash(req.mainQuery)
-                                prog.set(req.mainQuery, tempData)
+                                prog.set(tempData.infoHash, tempData)
                             }
                             if(req.mainPath === path.sep){
                                 if(req.mainReq){

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function makeBTFetch(opts = {}){
           try {
               let {hostname, pathname, protocol, searchParams} = new URL(url)
 
-              if((protocol !== 'bt:' || !method || !SUPPORTED_METHODS.includes(method) || !hostname) || (hostname.length === 1 && hostname !== hostType) || (hostname.length !== 1 && hostname.length !== 32 && hostname.length !== 40 && hostname.length !== 64) || (hostname.length !== 1 && !checkTitle.test(hostname) && !checkHash.test(hostname) && !checkAddress.test(hostname))){
+              if((protocol !== 'bt:' || !method || !SUPPORTED_METHODS.includes(method) || !hostname) || (hostname.length !== 1 && hostname.length !== 32 && hostname.length !== 40 && hostname.length !== 64) || (hostname.length === 1 && hostname !== hostType) || (hostname.length !== 1 && !checkTitle.test(hostname) && !checkHash.test(hostname) && !checkAddress.test(hostname))){
                   console.log('something wrong with the query')
                   throw new Error('invalid query, must be a valid query')
               }

--- a/index.js
+++ b/index.js
@@ -87,21 +87,12 @@ module.exports = function makeBTFetch(opts = {}){
                   
                 case 'GET': {
                     if(req.mainType){
-                        if(req.mainQuery){
-                            if(req.mainReq){
-                                res.data = ['<html><head><title>Config</title></head><body><div><p>hostname must be empty</p><div></body></html>']
-                            } else {
-                                res.data = [JSON.stringify('hostname must be empty')]
-                            }
-                            res.statusCode = 400
+                        if(req.mainReq){
+                            res.data = ['<html><head><title>Config</title></head><body><div><p>timeout: ' + app._status.timeout + '</p><p>Torrents: ' + app.webtorrent.torrents.length + '</p><p>initial: ' + app._status.initial + '</p><p>current: ' + app._status.current + '</p><p>share: ' + app._status.share + '</p><div></body></html>']
                         } else {
-                            if(req.mainReq){
-                                res.data = ['<html><head><title>Config</title></head><body><div><p>timeout: ' + app._status.timeout + '</p><p>Torrents: ' + app.webtorrent.torrents.length + '</p><p>initial: ' + app._status.initial + '</p><p>current: ' + app._status.current + '</p><p>share: ' + app._status.share + '</p><div></body></html>']
-                            } else {
-                                res.data = [JSON.stringify({timeout: app._timeOut, share: app._status.share, current: app._status.current, initial: app._status.initial, torrents: app.webtorrent.torrents.length})]
-                            }
-                            res.statusCode = 200
+                            res.data = [JSON.stringify({timeout: app._timeOut, share: app._status.share, current: app._status.current, initial: app._status.initial, torrents: app.webtorrent.torrents.length})]
                         }
+                        res.statusCode = 200
                         res.headers['Content-Type'] = req.mainRes
                     } else {
                         let tempData = null
@@ -304,58 +295,49 @@ module.exports = function makeBTFetch(opts = {}){
 
                 case 'DELETE': {
                     if(req.mainType){
-                        if(req.mainQuery){
+                        if(!body){
+                            prog.clear()
                             if(req.mainReq){
-                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>hostname must be empty</p></div></body></html>`]
+                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${app.clearData()}</p></div></body></html>`]
                             } else {
-                                res.data = [JSON.stringify('hostname must be empty')]
+                                res.data = [JSON.stringify(app.clearData())]
                             }
                             res.statusCode = 400
-                        } else {
-                            if(!body){
-                                prog.clear()
-                                if(req.mainReq){
-                                    res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${app.clearData()}</p></div></body></html>`]
-                                } else {
-                                    res.data = [JSON.stringify(app.clearData())]
-                                }
-                                res.statusCode = 400
-                                // mainData = [await app.clearData()]
-                                // prog.clear()
-                            } else if(body.hash){
-                                if(prog.has(body.hash)){
-                                    prog.delete(body.hash)
-                                }
-                                if(req.mainReq){
-                                    res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.removeHash(body.hash)}</p></div></body></html>`]
-                                } else {
-                                    res.data = [JSON.stringify(await app.removeHash(body.hash))]
-                                }
-                                res.statusCode = 200
-                            } else if(body.address){
-                                if(prog.has(body.address)){
-                                    prog.delete(body.address)
-                                }
-                                if(req.mainReq){
-                                    res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.removeAddress(body.address)}</p></div></body></html>`]
-                                } else {
-                                    res.data = [JSON.stringify(await app.removeAddress(body.address))]
-                                }
-                                res.statusCode = 200
-                            } else if(body.title){
-                                if(prog.has(body.title)){
-                                    prog.delete(body.title)
-                                }
-                                if(req.mainReq){
-                                    res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.removeTitle(body.title)}</p></div></body></html>`]
-                                } else {
-                                    res.data = [JSON.stringify(await app.removeTitle(body.title))]
-                                }
-                                res.statusCode = 200
-                            } else {
-                                res.data = [JSON.stringify('body is missing data')]
-                                res.statusCode = 400
+                            // mainData = [await app.clearData()]
+                            // prog.clear()
+                        } else if(body.hash){
+                            if(prog.has(body.hash)){
+                                prog.delete(body.hash)
                             }
+                            if(req.mainReq){
+                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.removeHash(body.hash)}</p></div></body></html>`]
+                            } else {
+                                res.data = [JSON.stringify(await app.removeHash(body.hash))]
+                            }
+                            res.statusCode = 200
+                        } else if(body.address){
+                            if(prog.has(body.address)){
+                                prog.delete(body.address)
+                            }
+                            if(req.mainReq){
+                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.removeAddress(body.address)}</p></div></body></html>`]
+                            } else {
+                                res.data = [JSON.stringify(await app.removeAddress(body.address))]
+                            }
+                            res.statusCode = 200
+                        } else if(body.title){
+                            if(prog.has(body.title)){
+                                prog.delete(body.title)
+                            }
+                            if(req.mainReq){
+                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.removeTitle(body.title)}</p></div></body></html>`]
+                            } else {
+                                res.data = [JSON.stringify(await app.removeTitle(body.title))]
+                            }
+                            res.statusCode = 200
+                        } else {
+                            res.data = [JSON.stringify('body is missing data')]
+                            res.statusCode = 400
                         }
                         res.headers['Content-Type'] = req.mainRes
                     } else {

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = function makeBTFetch (opts = {}) {
                 } else {
                   tempPath = torrentData.path + path.sep + torrentData.name + path.sep
                 }
-                const foundFile = torrentData.files.find(file => { file.path.replace(tempPath, '') === req.mainPath })
+                const foundFile = torrentData.files.find(file => { return path.sep + file.path.replace(tempPath, '') === req.mainPath })
                 if (foundFile) {
                   res.headers['Content-Type'] = getMimeType(req.mainPath)
                   res.headers['Content-Length'] = `${foundFile.length}`
@@ -168,7 +168,7 @@ module.exports = function makeBTFetch (opts = {}) {
               res.headers['Content-Type'] = req.mainRes
               res.headers['Content-Length'] = torrentData.length
             } else {
-              foundFile = torrentData.files.find(file => { file.path.replace(tempPath, '') === req.mainPath })
+              foundFile = torrentData.files.find(file => { return path.sep + file.path.replace(tempPath, '') === req.mainPath })
               if (foundFile) {
                 if (req.mainRange) {
                   const ranges = parseRange(foundFile.length, req.mainRange)

--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ module.exports = function makeBTFetch(opts = {}){
                             }
                         } else {
                             if(body.address === undefined || body.secret === undefined){
-                                let {torrent, title} = await app.publishHash(body.folder)
+                                let {torrent, title} = await app.publishTitle(body.folder)
                                 if(prog.has(torrent.infoHash)){
                                     prog.delete(torrent.infoHash)
                                     prog.set(torrent.infoHash, torrent)

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const HASH_REGEX = /^[a-fA-F0-9]{40}$/
 const ADDRESS_REGEX = /^[a-fA-F0-9]{64}$/
 const PETNAME_REGEX = /^(?:-|[a-zA-Z0-9]|_)+$/
 // const DOMAIN_REGEX = /^(?:-|[a-zA-Z0-9]|\.)+$/
-const META_HOSTNAME = '$'
+const META_HOSTNAME = 'localhost'
 const DEFAULT_OPTS = {
   folder: __dirname,
   storage: 'storage',

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ module.exports = function makeBTFetch (opts = {}) {
                   res.headers['X-Downloaded'] = `${foundFile.downloaded}`
                   res.statusCode = 200
                 } else {
-                  res.statusCode = 400
+                  res.statusCode = 404
                   res.headers['Content-Length'] = 0
                 }
               }

--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ module.exports = function makeBTFetch (opts = {}) {
             } else if(req.mainUpdate === false){
                 const { torrent, hash } = await app.publishHash(null, reqHeaders, body)
                 prog.set(torrent.hash, torrent)
-                res.data = req.mainReq ? [`<html><head><title>${torrent.hash}</title></head><body><div><p>infohash: ${torrent.infoHash}</p><p>folder: ${hash}</p></div></body></html>`] : [JSON.stringify({ infohash: torrent.hash, hash })]
+                res.data = req.mainReq ? [`<html><head><title>${torrent.hash}</title></head><body><div><p>infohash: ${torrent.infoHash}</p><p>folder: ${hash}</p></div></body></html>`] : [JSON.stringify({ infohash: torrent.infoHash, hash })]
                 res.statusCode = 200
             }
             res.headers['Content-Type'] = req.mainRes

--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ function findFile (torrent, filePath) {
 
 function findDirectoryFiles (torrent, directoryPath) {
   return torrent.files
-    .filter(({ path }) => path.startsWith(directoryPath))
+    .filter(({ relativePath }) => relativePath.startsWith(directoryPath))
     .map(({ relativePath }) => relativePath.slice(directoryPath.length))
     .reduce((final, file) => {
       const segments = file.split('/')

--- a/index.js
+++ b/index.js
@@ -204,7 +204,7 @@ module.exports = function makeBTFetch (opts = {}) {
               res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>body is required</p></div></body></html>'] : [JSON.stringify('body is required')]
               res.statusCode = 400
             } else if(req.mainUpdate === null){
-              res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>url param "update" is required</p></div></body></html>'] : [JSON.stringify('url param "kind" is required')]
+              res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>url param "update" is required</p></div></body></html>'] : [JSON.stringify('url param "update" is required')]
               res.statusCode = 400
             } else {
               if(req.mainUpdate === true){

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function makeBTFetch(opts = {}){
                 case 'GET': {
                     if(req.mainType){
                         if(req.mainReq){
-                            res.data = ['<html><head><title>Config</title></head><body><div><p>timeout: ' + app._status.timeout + '</p><p>Torrents: ' + app.webtorrent.torrents.length + '</p><p>initial: ' + app._status.initial + '</p><p>current: ' + app._status.current + '</p><p>share: ' + app._status.share + '</p><div></body></html>']
+                            res.data = ['<html><head><title>BT-Fetch</title></head><body><div><p>timeout: ' + app._status.timeout + '</p><p>Torrents: ' + app.webtorrent.torrents.length + '</p><p>initial: ' + app._status.initial + '</p><p>current: ' + app._status.current + '</p><p>share: ' + app._status.share + '</p><div></body></html>']
                         } else {
                             res.data = [JSON.stringify({timeout: app._timeOut, share: app._status.share, current: app._status.current, initial: app._status.initial, torrents: app.webtorrent.torrents.length})]
                         }
@@ -223,7 +223,7 @@ module.exports = function makeBTFetch(opts = {}){
                                         prog.set(torrent.infoHash, torrent)
                                     }
                                     if(req.mainReq){
-                                        res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>infohash: ${torrent.infoHash}</p><p>folder: ${title}</p></div></body></html>`]
+                                        res.data = [`<html><head><title>${torrent.title}</title></head><body><div><p>infohash: ${torrent.infoHash}</p><p>folder: ${title}</p></div></body></html>`]
                                     } else {
                                         res.data = [JSON.stringify({infohash: torrent.infoHash, title})]
                                     }
@@ -237,7 +237,7 @@ module.exports = function makeBTFetch(opts = {}){
                                         prog.set(torrent.address, torrent)
                                     }
                                     if(req.mainReq){
-                                        res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p><p>sequence: ${torrent.sequence}</p><p>signature: ${torrent.sig}</p><p>magnet: ${torrent.magnet}</p><p>secret: ${secret}</p></div></body></html>`]
+                                        res.data = [`<html><head><title>${torrent.address}</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p><p>sequence: ${torrent.sequence}</p><p>signature: ${torrent.sig}</p><p>magnet: ${torrent.magnet}</p><p>secret: ${secret}</p></div></body></html>`]
                                     } else {
                                         res.data = [JSON.stringify({address: torrent.address, infohash: torrent.infoHash, sequence: torrent.sequence, magnet: torrent.magnet, signature: torrent.sig, secret})]
                                     }
@@ -263,7 +263,7 @@ module.exports = function makeBTFetch(opts = {}){
                                 prog.set(torrent.address, torrent)
                             }
                             if(req.mainReq){
-                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p></div></body></html>`]
+                                res.data = [`<html><head><title>${torrent.address}</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p></div></body></html>`]
                             } else {
                                 res.data = [JSON.stringify({address: torrent.address, infoHash: torrent.infoHash})]
                             }
@@ -277,7 +277,7 @@ module.exports = function makeBTFetch(opts = {}){
                                 prog.set(torrent.infoHash, torrent)
                             }
                             if(req.mainReq){
-                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>title: ${torrent.title}</p><p>infohash: ${torrent.infoHash}</p></div></body></html>`]
+                                res.data = [`<html><head><title>${torrent.title}</title></head><body><div><p>title: ${torrent.title}</p><p>infohash: ${torrent.infoHash}</p></div></body></html>`]
                             } else {
                                 res.data = [JSON.stringify({title: torrent.title, infoHash: torrent.infoHash})]
                             }
@@ -305,7 +305,7 @@ module.exports = function makeBTFetch(opts = {}){
                                 prog.delete(body.hash)
                             }
                             if(req.mainReq){
-                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.removeHash(body.hash)}</p></div></body></html>`]
+                                res.data = [`<html><head><title>${body.hash}</title></head><body><div><p>${await app.removeHash(body.hash)}</p></div></body></html>`]
                             } else {
                                 res.data = [JSON.stringify(await app.removeHash(body.hash))]
                             }
@@ -315,7 +315,7 @@ module.exports = function makeBTFetch(opts = {}){
                                 prog.delete(body.address)
                             }
                             if(req.mainReq){
-                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.removeAddress(body.address)}</p></div></body></html>`]
+                                res.data = [`<html><head><title>${body.address}</title></head><body><div><p>${await app.removeAddress(body.address)}</p></div></body></html>`]
                             } else {
                                 res.data = [JSON.stringify(await app.removeAddress(body.address))]
                             }
@@ -325,7 +325,7 @@ module.exports = function makeBTFetch(opts = {}){
                                 prog.delete(body.title)
                             }
                             if(req.mainReq){
-                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.removeTitle(body.title)}</p></div></body></html>`]
+                                res.data = [`<html><head><title>${body.title}</title></head><body><div><p>${await app.removeTitle(body.title)}</p></div></body></html>`]
                             } else {
                                 res.data = [JSON.stringify(await app.removeTitle(body.title))]
                             }
@@ -341,7 +341,7 @@ module.exports = function makeBTFetch(opts = {}){
                                 prog.delete(req.mainQuery)
                             }
                             if(req.mainReq){
-                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${app.stopAddress(req.mainQuery)}</p></div></body></html>`]
+                                res.data = [`<html><head><title>${req.mainQuery}</title></head><body><div><p>${app.stopAddress(req.mainQuery)}</p></div></body></html>`]
                             } else {
                                 res.data = [JSON.stringify(app.stopAddress(req.mainQuery))]
                             }
@@ -351,7 +351,7 @@ module.exports = function makeBTFetch(opts = {}){
                                 prog.delete(req.mainQuery)
                             }
                             if(req.mainReq){
-                                mainData = [`<html><head><title>BT-Fetch</title></head><body><div><p>${app.stopHash(req.mainQuery)}</p></div></body></html>`]
+                                mainData = [`<html><head><title>${req.mainQuery}</title></head><body><div><p>${app.stopHash(req.mainQuery)}</p></div></body></html>`]
                             } else {
                                 mainData = [JSON.stringify(app.stopHash(req.mainQuery))]
                             }
@@ -361,7 +361,7 @@ module.exports = function makeBTFetch(opts = {}){
                                 prog.delete(req.mainQuery)
                             }
                             if(req.mainReq){
-                                mainData = [`<html><head><title>BT-Fetch</title></head><body><div><p>${app.stopTitle(req.mainQuery)}</p></div></body></html>`]
+                                mainData = [`<html><head><title>${req.mainQuery}</title></head><body><div><p>${app.stopTitle(req.mainQuery)}</p></div></body></html>`]
                             } else {
                                 mainData = [JSON.stringify(app.stopTitle(req.mainQuery))]
                             }

--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ module.exports = function makeBTFetch(opts = {}){
                     } else {
                         let tempData = null
                         let foundFile = null
+                        let tempPath = null
                         if(req.mainQuery.length === 64){
                             if(prog.has(req.mainQuery)){
                                 tempData = prog.get(req.mainQuery)
@@ -104,19 +105,16 @@ module.exports = function makeBTFetch(opts = {}){
                                 tempData = await app.loadAddress(req.mainQuery)
                                 prog.set(tempData.address, tempData)
                             }
+                            if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
+                                tempPath = tempData.path + path.sep
+                            } else {
+                                tempPath = tempData.path + path.sep + tempData.name + path.sep
+                            }
                             if(req.mainPath === path.sep){
                                 if(req.mainReq){
-                                    if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
-                                        res.data = [`<html><head><title>${tempData.address}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
-                                    } else {
-                                        res.data = [`<html><head><title>${tempData.address}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
-                                    }
+                                    res.data = [`<html><head><title>${tempData.address}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempPath, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                 } else {
-                                    if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
-                                        res.data = [JSON.stringify(tempData.files.map(file => {return 'bt://' + tempData.address + '/' + file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}))]
-                                    } else {
-                                        res.data = [JSON.stringify(tempData.files.map(file => {return 'bt://' + tempData.address + '/' + file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}))]
-                                    }
+                                    res.data = [JSON.stringify(tempData.files.map(file => {return 'bt://' + tempData.address + '/' + file.path.replace(tempPath, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}))]
                                 }
                                 res.statusCode = 200
                                 res.headers['Content-Type'] = req.mainRes
@@ -157,19 +155,16 @@ module.exports = function makeBTFetch(opts = {}){
                                 tempData = await app.loadHash(req.mainQuery)
                                 prog.set(tempData.infoHash, tempData)
                             }
+                            if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
+                                tempPath = tempData.path + path.sep
+                            } else {
+                                tempPath = tempData.path + path.sep + tempData.name + path.sep
+                            }
                             if(req.mainPath === path.sep){
                                 if(req.mainReq){
-                                    if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
-                                        res.data = [`<html><head><title>${tempData.infoHash}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
-                                    } else {
-                                        res.data = [`<html><head><title>${tempData.infoHash}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
-                                    }
+                                    res.data = [`<html><head><title>${tempData.infoHash}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempPath, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                 } else {
-                                    if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
-                                        res.data = [JSON.stringify(tempData.files.map(file => {return 'bt://' + tempData.infoHash + '/' + file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}))]
-                                    } else {
-                                        res.data = [JSON.stringify(tempData.files.map(file => {return 'bt://' + tempData.infoHash + '/' + file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}))]
-                                    }
+                                    res.data = [JSON.stringify(tempData.files.map(file => {return 'bt://' + tempData.infoHash + '/' + file.path.replace(tempPath, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}))]
                                 }
                                 res.statusCode = 200
                                 res.headers['Content-Type'] = req.mainRes

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const DEFAULT_OPTS = {
     magnet: 'magnet',
 }
 
-module.exports = function makeGunFetch(opts = {}){
+module.exports = function makeBTFetch(opts = {}){
     const finalOpts = {...DEFAULT_OPTS, ...opts}
 
     const SUPPORTED_METHODS = ['GET', 'POST', 'DELETE', 'PATCH']

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function makeBTFetch(opts = {}){
     // const sideType = '-'
     const hostType = '_'
 
-    const app = new Main({folder: finalOpts.folder, storage: finalOpts.storage, author: finalOpts.author})
+    const app = new Main(finalOpts)
 
     const prog = new Map()
 

--- a/index.js
+++ b/index.js
@@ -164,16 +164,7 @@ module.exports = function makeBTFetch (opts = {}) {
   })
 
   fetch.destroy = () => {
-    return new Promise((resolve, reject) => {
-      clearInterval(torrents.updateRoutine)
-      torrents.webtorrent.destroy(error => {
-        if (error) {
-          reject(error)
-        } else {
-          resolve()
-        }
-      })
-    })
+    return torrents.destroy()
   }
 
   return fetch

--- a/index.js
+++ b/index.js
@@ -107,9 +107,9 @@ module.exports = function makeBTFetch(opts = {}){
                             if(req.mainPath === path.sep){
                                 if(req.mainReq){
                                     if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
-                                        res.data = [`<html><head><title>BT-Fetch</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
+                                        res.data = [`<html><head><title>${tempData.name}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                     } else {
-                                        res.data = [`<html><head><title>BT-Fetch</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
+                                        res.data = [`<html><head><title>${tempData.name}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                     }
                                 } else {
                                     if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
@@ -160,9 +160,9 @@ module.exports = function makeBTFetch(opts = {}){
                             if(req.mainPath === path.sep){
                                 if(req.mainReq){
                                     if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
-                                        res.data = [`<html><head><title>BT-Fetch</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
+                                        res.data = [`<html><head><title>${tempData.name}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                     } else {
-                                        res.data = [`<html><head><title>BT-Fetch</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
+                                        res.data = [`<html><head><title>${tempData.name}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                     }
                                 } else {
                                     if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){

--- a/index.js
+++ b/index.js
@@ -145,9 +145,9 @@ module.exports = function makeBTFetch(opts = {}){
                             if(req.mainPath === path.sep){
                                 if(req.mainReq){
                                     if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
-                                        mainData = [`<html><head><title>BT-Fetch</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.path}</a> - ${file.name}</p>`})}</div></body></html>`]
+                                        mainData = [`<html><head><title>BT-Fetch</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                     } else {
-                                        mainData = [`<html><head><title>BT-Fetch</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.path}</a> - ${file.name}</p>`})}</div></body></html>`]
+                                        mainData = [`<html><head><title>BT-Fetch</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempData.path + path.sep + tempData.name + path.sep, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
                                     }
                                 } else {
                                     if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ module.exports = function makeBTFetch(opts = {}){
                                 res.headers['Content-Type'] = req.mainRes
                                 res.headers['Content-Length'] = tempData.length
                             } else {
-                                foundFile = tempData.files.find(file => {return file.endsWith(req.mainPath)})
+                                foundFile = tempData.files.find(file => {return file.path.endsWith(req.mainPath)})
                                 if(foundFile){
                                     if(req.mainRange){
                                         let ranges = parseRange(foundFile.length, req.mainRange)

--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ module.exports = function makeBTFetch(opts = {}){
                         res.headers['Content-Type'] = req.mainRes
                     } else {
                         if(req.mainQuery.length === 64){
-                            let torrent = await app.ownAddress(req.mainQuery)
+                            let torrent = await app.currentAddress(req.mainQuery)
                             if(prog.has(torrent.address)){
                                 prog.delete(torrent.address)
                                 prog.set(torrent.address, torrent)
@@ -283,7 +283,7 @@ module.exports = function makeBTFetch(opts = {}){
                             }
                             res.statusCode = 200
                         } else if(req.mainQuery.length === 32){
-                            let torrent = await app.ownTitle(req.mainQuery)
+                            let torrent = await app.currentTitle(req.mainQuery)
                             if(prog.has(torrent.infoHash)){
                                 prog.delete(torrent.infoHash)
                                 prog.set(torrent.infoHash, torrent)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const makeFetch = require('make-fetch')
 const path = require('path')
-const BTP = require('btp-torrent')
+const BTFetchTorrent = require('bt-fetch-torrent')
 const streamToIterator = require('stream-async-iterator')
 const mime = require('mime/lite')
 
@@ -20,7 +20,7 @@ module.exports = function makeBTFetch(opts = {}){
     // const sideType = '-'
     const hostType = '_'
 
-    const app = new BTP({folder: finalOpts.folder, storage: finalOpts.storage, magnet: finalOpts.magnet})
+    const app = new BTFetchTorrent({folder: finalOpts.folder, storage: finalOpts.storage, magnet: finalOpts.magnet})
 
     const prog = new Map()
 

--- a/index.js
+++ b/index.js
@@ -235,10 +235,17 @@ module.exports = function makeBTFetch (opts = {}) {
                 prog.delete(req.mainQuery)
               }
               if(req.mainQuery.length === 64){
-                const { torrent, secret } = await app.publishAddress({address: req.mainQuery, secret: reqHeaders['Authorization']}, reqHeaders, body)
-                prog.set(torrent.address, torrent)
-                res.data = req.mainReq ? [`<html><head><title>${torrent.address}</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p><p>sequence: ${torrent.sequence}</p><p>signature: ${torrent.sig}</p><p>magnet: ${torrent.magnet}</p><p>secret: ${secret}</p></div></body></html>`] : [JSON.stringify({ address: torrent.address, infohash: torrent.infoHash, sequence: torrent.sequence, magnet: torrent.magnet, signature: torrent.sig, secret })]
-                res.statusCode = 200
+                if(!reqHeaders['Authorization']){
+                  res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>secret key is required in the Authorizatiion header</p></div></body></html>'] : [JSON.stringify('secret key is needed inside the Authorization header')]
+                  res.statusCode = 400
+                } else {
+                  // const tempSecret = reqHeaders['Authorization']
+                  // delete reqHeaders['Authorization']
+                  const { torrent, secret } = await app.publishAddress({address: req.mainQuery, secret: reqHeaders['Authorization']}, reqHeaders, body)
+                  prog.set(torrent.address, torrent)
+                  res.data = req.mainReq ? [`<html><head><title>${torrent.address}</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p><p>sequence: ${torrent.sequence}</p><p>signature: ${torrent.sig}</p><p>magnet: ${torrent.magnet}</p><p>secret: ${secret}</p></div></body></html>`] : [JSON.stringify({ address: torrent.address, infohash: torrent.infoHash, sequence: torrent.sequence, magnet: torrent.magnet, signature: torrent.sig, secret })]
+                  res.statusCode = 200
+                }
               } else if(req.mainQuery.length === 40){
                 const { torrent, hash } = await app.publishHash(req.mainQuery, reqHeaders, body)
                 prog.set(torrent.hash, torrent)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const makeFetch = require('make-fetch')
 const path = require('path')
-const fs = require('fs-extra')
 const BTP = require('btp-torrent')
 const streamToIterator = require('stream-async-iterator')
 const mime = require('mime/lite')

--- a/index.js
+++ b/index.js
@@ -51,9 +51,10 @@ module.exports = function makeBTFetch(opts = {}){
               switch (req.mainMethod) {
 
                 case 'HEAD': {
-                    let mainData = []
-                    let checkCode = null
                     if(req.mainType){
+                        let mainData = []
+                        let mainLength = 0
+                        let checkCode = null
                         if(req.mainQuery){
                             if(prog.has(req.mainQuery)){
                                 checkCode = 200
@@ -65,9 +66,11 @@ module.exports = function makeBTFetch(opts = {}){
                         }
                         res.data = mainData
                         res.statusCode = checkCode
-                        res.headers = {}
+                        res.headers['Content-Length'] = mainLength
                     } else {
                         let mainLength = null
+                        let mainData = []
+                        let checkCode = null
                         if(prog.has(req.mainQuery)){
                             checkCode = 200
                             mainLength = prog.get(req.mainQuery).length
@@ -76,7 +79,7 @@ module.exports = function makeBTFetch(opts = {}){
                             mainLength = 0
                         }
                         res.data = mainData
-                        res.headers = {'Content-Length': mainLength}
+                        res.headers['Content-Length'] = mainLength
                         res.statusCode = checkCode
                     }
                     break

--- a/index.js
+++ b/index.js
@@ -96,9 +96,9 @@ module.exports = function makeBTFetch(opts = {}){
                             res.statusCode = 400
                         } else {
                             if(req.mainReq){
-                                res.data = ['<html><head><title>Config</title></head><body><div><p>timeout: ' + app._status.timeout + '</p><p>Torrents: ' + app.webtorrent.torrents.length + '</p><p>initial: ' + app._status.initial + '</p><p>current: ' + app._status.current + '</p><p>share: ' + app._status.share + '</p><p>clear: ' + app._status.clear + '</p><div></body></html>']
+                                res.data = ['<html><head><title>Config</title></head><body><div><p>timeout: ' + app._status.timeout + '</p><p>Torrents: ' + app.webtorrent.torrents.length + '</p><p>initial: ' + app._status.initial + '</p><p>current: ' + app._status.current + '</p><p>share: ' + app._status.share + '</p><div></body></html>']
                             } else {
-                                res.data = [JSON.stringify({timeout: app._timeOut, share: app._status.share, current: app._status.current, initial: app._status.initial, clear: app._status.clear, torrents: app.webtorrent.torrents.length})]
+                                res.data = [JSON.stringify({timeout: app._timeOut, share: app._status.share, current: app._status.current, initial: app._status.initial, torrents: app.webtorrent.torrents.length})]
                             }
                             res.statusCode = 200
                         }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const checkTitle = new RegExp('^[a-f0-9]{32}$')
 const DEFAULT_OPTS = {
     folder: __dirname,
     storage: 'storage',
-    magnet: 'magnet',
+    files: 'magnet',
 }
 
 module.exports = function makeBTFetch(opts = {}){
@@ -21,7 +21,7 @@ module.exports = function makeBTFetch(opts = {}){
     // const sideType = '-'
     const hostType = '_'
 
-    const app = new BTFetchTorrent({folder: finalOpts.folder, storage: finalOpts.storage, magnet: finalOpts.magnet})
+    const app = new BTFetchTorrent({folder: finalOpts.folder, storage: finalOpts.storage, files: finalOpts.files})
 
     const prog = new Map()
 

--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ module.exports = function makeBTFetch (opts = {}) {
             } else if(req.mainUpdate === null){
               res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>url param "update" is required</p></div></body></html>'] : [JSON.stringify('url param "update" is required')]
               res.statusCode = 400
-            } else if(!reqHeaders['Content-Type'] || !reqHeaders['Content-Type'].includes('multipart/form-data')){
+            } else if(!reqHeaders['content-type'] || !reqHeaders['content-type'].includes('multipart/form-data')){
               res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>Content-Type header is invalud</p></div></body></html>'] : [JSON.stringify('Content-Type header is invalid')]
               res.statusCode = 400
             } else {

--- a/index.js
+++ b/index.js
@@ -250,18 +250,26 @@ module.exports = function makeBTFetch(opts = {}){
 
                 case 'DELETE': {
                     let mainData = null
+                    let checkCode = null
                     if(req.mainType){
                         if(!body){
                             if(req.mainReq){
-                                mainData = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.clearData()}</p></div></body></html>`]
+                                mainData = ['<html><head><title>BT-Fetch</title></head><body><div><p>body is required</p></div></body></html>']
                             } else {
-                                mainData = [JSON.stringify(await app.clearData())]
+                                mainData = [JSON.stringify('body is required')]
                             }
-                            prog.clear()
+                            checkCode = 400
                             // mainData = [await app.clearData()]
                             // prog.clear()
                         } else {
-                            if(body.hash){
+                            if(body.remove !== undefined){
+                                if(req.mainReq){
+                                    mainData = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.clearData(body.remove)}</p></div></body></html>`]
+                                } else {
+                                    mainData = [JSON.stringify(await app.clearData(body.remove))]
+                                }
+                                prog.clear()
+                            } else if(body.hash){
                                 if(req.mainReq){
                                     mainData = [`<html><head><title>BT-Fetch</title></head><body><div><p>${await app.removeHash(body.hash)}</p></div></body></html>`]
                                 } else {
@@ -292,9 +300,10 @@ module.exports = function makeBTFetch(opts = {}){
                                     prog.delete(body.title)
                                 }
                             }
+                            checkCode = 200
                         }
                         res.data = mainData
-                        res.statusCode = 200
+                        res.statusCode = checkCode
                         res.headers['Content-Type'] = req.mainRes
                     } else {
                         if(req.mainQuery.length === 64){

--- a/index.js
+++ b/index.js
@@ -225,9 +225,6 @@ module.exports = function makeBTFetch (opts = {}) {
             res.headers['Content-Type'] = req.mainRes
           } else {
             if(!body){
-              if(prog.has(req.mainQuery)){
-                prog.delete(req.mainQuery)
-              }
               res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>body is required</p></div></body></html>'] : [JSON.stringify('body is required')]
               res.statusCode = 400
             } else if(!reqHeaders['Content-Type'] || !reqHeaders['Content-Type'].includes('multipart/form-data;')){

--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ module.exports = function makeBTFetch (opts = {}) {
             } else if(req.mainUpdate === null){
               res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>url param "update" is required</p></div></body></html>'] : [JSON.stringify('url param "update" is required')]
               res.statusCode = 400
-            } else if(!reqHeaders['Content-Type'] || !reqHeaders['Content-Type'].includes('multipart/form-data;')){
+            } else if(!reqHeaders['Content-Type'] || !reqHeaders['Content-Type'].includes('multipart/form-data')){
               res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>Content-Type header is invalud</p></div></body></html>'] : [JSON.stringify('Content-Type header is invalid')]
               res.statusCode = 400
             } else {
@@ -227,7 +227,7 @@ module.exports = function makeBTFetch (opts = {}) {
             if(!body){
               res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>body is required</p></div></body></html>'] : [JSON.stringify('body is required')]
               res.statusCode = 400
-            } else if(!reqHeaders['Content-Type'] || !reqHeaders['Content-Type'].includes('multipart/form-data;')){
+            } else if(!reqHeaders['content-type'] || !reqHeaders['content-type'].includes('multipart/form-data')){
               res.data = req.mainReq ? ['<html><head><title>BT-Fetch</title></head><body><div><p>Content-Type header is invalud</p></div></body></html>'] : [JSON.stringify('Content-Type header is invalid')]
               res.statusCode = 400
             } else {

--- a/index.js
+++ b/index.js
@@ -9,422 +9,425 @@ const checkHash = new RegExp('^[a-fA-F0-9]{40}$')
 const checkAddress = new RegExp('^[a-fA-F0-9]{64}$')
 const checkTitle = new RegExp('^[a-f0-9]{32}$')
 const DEFAULT_OPTS = {
-    folder: __dirname,
-    storage: 'storage',
-    author: 'author',
+  folder: __dirname,
+  storage: 'storage',
+  author: 'author'
 }
 
-module.exports = function makeBTFetch(opts = {}){
-    const finalOpts = {...DEFAULT_OPTS, ...opts}
+module.exports = function makeBTFetch (opts = {}) {
+  const finalOpts = { ...DEFAULT_OPTS, ...opts }
 
-    const SUPPORTED_METHODS = ['GET', 'POST', 'DELETE', 'HEAD']
-    // const sideType = '-'
-    const hostType = '_'
+  const SUPPORTED_METHODS = ['GET', 'POST', 'DELETE', 'HEAD']
+  // const sideType = '-'
+  const hostType = '_'
 
-    const app = new Main(finalOpts)
+  const app = new Main(finalOpts)
 
-    const prog = new Map()
+  const prog = new Map()
 
-    const fetch = makeFetch(async request => {
+  async function getBody (body) {
+    let mainData = ''
 
-        if(request.body !== null){
-            request.body = await getBody(request.body)
-            try {
-                request.body = JSON.parse(request.body)
-            } catch (error) {
-                console.log(error)
-            }
-        }
+    for await (const data of body) {
+      mainData += data
+    }
 
-        const {url, method, headers: reqHeaders, body} = request
+    return mainData
+  }
 
-          try {
-              let {hostname, pathname, protocol, searchParams} = new URL(url)
+  function getMimeType (path) {
+    let mimeType = mime.getType(path) || 'text/plain'
+    if (mimeType.startsWith('text/')) mimeType = `${mimeType}; charset=utf-8`
+    return mimeType
+  }
 
-              if((protocol !== 'bt:' || !method || !SUPPORTED_METHODS.includes(method) || !hostname) || (hostname.length !== 1 && hostname.length !== 32 && hostname.length !== 40 && hostname.length !== 64) || (hostname.length === 1 && hostname !== hostType) || (hostname.length !== 1 && !checkTitle.test(hostname) && !checkHash.test(hostname) && !checkAddress.test(hostname))){
-                  console.log('something wrong with the query')
-                  throw new Error('invalid query, must be a valid query')
-              }
+  function formatReq (hostname, pathname, method, search, headers) {
+    // let mainType = hostname[0] === hostType || hostname[0] === sideType ? hostname[0] : ''
+    const mainType = hostname[0] === hostType
+    const mainQuery = mainType ? hostname.replace(hostname[0], '') : hostname
+    const mainHost = hostname
+    // if(pathname){
+    //     console.log(decodeURIComponent(pathname))
+    // }
+    const mainPath = pathname ? decodeURIComponent(pathname).replace(/\//g, path.sep) : path.sep
+    const mainMethod = method
+    const mainReq = headers.accept && headers.accept.includes('text/html')
+    const mainRes = mainReq ? 'text/html; charset=utf-8' : 'application/json; charset=utf-8'
+    const mainReg = !!search.get('clear')
+    const mainRange = headers.Range || headers.range
+    return { mainQuery, mainHost, mainPath, mainMethod, mainReg, mainReq, mainRes, mainType, mainRange }
+  }
 
-              let req = formatReq(hostname, pathname, method, searchParams, reqHeaders)
+  const fetch = makeFetch(async request => {
+    if (request.body !== null) {
+      request.body = await getBody(request.body)
+      try {
+        request.body = JSON.parse(request.body)
+      } catch (error) {
+        console.log(error)
+      }
+    }
 
-              let res = {statusCode: 400, headers: {}, data: []}
-              switch (req.mainMethod) {
+    const { url, method, headers: reqHeaders, body } = request
 
-                case 'HEAD': {
-                    if(req.mainType){
-                        res.statusCode = 400
-                        res.headers['Content-Length'] = 0
-                    } else {
-                        if(prog.has(req.mainQuery)){
-                            let tempData = prog.get(req.mainQuery)
-                            if(req.mainPath === path.sep){
-                                res.headers['Content-Type'] = req.mainRes
-                                res.headers['Content-Length'] = `${tempData.length}`
-                                res.headers['Accept-Ranges'] = 'bytes'
-                                res.headers['X-Downloaded'] = `${tempData.downloaded}`
-                                res.statusCode = 200
-                            } else {
-                                let foundFile = tempData.files.find(data => {return data.path.endsWith(req.mainPath)})
-                                if(foundFile){
-                                    res.headers['Content-Type'] = getMimeType(req.mainPath)
-                                    res.headers['Content-Length'] = `${foundFile.length}`
-                                    res.headers['Accept-Ranges'] = 'bytes'
-                                    res.headers['X-Downloaded'] = `${foundFile.downloaded}`
-                                    res.statusCode = 200
-                                } else {
-                                    res.statusCode = 400
-                                    res.headers['Content-Length'] = 0
-                                }
-                            }
-                        } else {
-                            res.statusCode = 400
-                            res.headers['Content-Length'] = 0
-                        }
-                    }
-                    break
-                }
-                  
-                case 'GET': {
-                    if(req.mainType){
-                        if(req.mainReq){
-                            res.data = ['<html><head><title>BT-Fetch</title></head><body><div><p>timeout: ' + app._status.timeout + '</p><p>Torrents: ' + app.webtorrent.torrents.length + '</p><p>initial: ' + app._status.initial + '</p><p>current: ' + app._status.current + '</p><p>share: ' + app._status.share + '</p><div></body></html>']
-                        } else {
-                            res.data = [JSON.stringify({timeout: app._timeOut, share: app._status.share, current: app._status.current, initial: app._status.initial, torrents: app.webtorrent.torrents.length})]
-                        }
-                        res.statusCode = 200
-                        res.headers['Content-Type'] = req.mainRes
-                    } else {
-                        let tempData = null
-                        let foundFile = null
-                        let tempPath = null
-                        if(req.mainQuery.length === 64){
-                            if(prog.has(req.mainQuery)){
-                                tempData = prog.get(req.mainQuery)
-                            } else {
-                                tempData = await app.loadAddress(req.mainQuery)
-                                prog.set(tempData.address, tempData)
-                            }
-                            if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
-                                tempPath = tempData.path + path.sep
-                            } else {
-                                tempPath = tempData.path + path.sep + tempData.name + path.sep
-                            }
-                            if(req.mainPath === path.sep){
-                                if(req.mainReq){
-                                    res.data = [`<html><head><title>${tempData.address}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.address}/${file.path.replace(tempPath, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
-                                } else {
-                                    res.data = [JSON.stringify(tempData.files.map(file => {return 'bt://' + tempData.address + '/' + file.path.replace(tempPath, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}))]
-                                }
-                                res.statusCode = 200
-                                res.headers['Content-Type'] = req.mainRes
-                                res.headers['Content-Length'] = tempData.length
-                            } else {
-                                foundFile = tempData.files.find(file => {return file.path.endsWith(req.mainPath)})
-                                if(foundFile){
-                                    if(req.mainRange){
-                                        let ranges = parseRange(foundFile.length, req.mainRange)
-                                        if(ranges && ranges.length && ranges.type === 'bytes'){
-                                            let [{ start, end }] = ranges
-                                            let length = (end - start + 1)
-                                            req.mainPartial.start = start
-                                            req.mainPartial.end = end
+    try {
+      const { hostname, pathname, protocol, searchParams } = new URL(url)
 
-                                            res.headers['Content-Length'] = `${length}`
-                                            res.headers['Content-Range'] = `bytes ${start}-${end}/${foundFile.length}`
-                                        }
-                                        res.statusCode = 206
-                                        res.data = streamToIterator(foundFile.createReadStream(req.mainPartial))
-                                        res.headers['Content-Type'] = getMimeType(req.mainPath)
-                                    } else {
-                                        res.data = streamToIterator(foundFile.createReadStream())
-                                        res.headers['Content-Type'] = getMimeType(req.mainPath)
-                                        res.headers['Content-Length'] = foundFile.length
-                                        res.statusCode = 200
-                                    }
-                                } else {
-                                    res.data = [JSON.stringify('file was not found')]
-                                    res.statusCode = 400
-                                    res.headers['Content-Type'] = 'application/json; charset=utf-8'
-                                }
-                            }
-                        } else if(req.mainQuery.length === 40){
-                            if(prog.has(req.mainQuery)){
-                                tempData = prog.get(req.mainQuery)
-                            } else {
-                                tempData = await app.loadHash(req.mainQuery)
-                                prog.set(tempData.infoHash, tempData)
-                            }
-                            if(tempData.files.length === 1 && tempData.name === tempData.files[0].name){
-                                tempPath = tempData.path + path.sep
-                            } else {
-                                tempPath = tempData.path + path.sep + tempData.name + path.sep
-                            }
-                            if(req.mainPath === path.sep){
-                                if(req.mainReq){
-                                    res.data = [`<html><head><title>${tempData.infoHash}</title></head><body><div>${tempData.files.map(file => {return `<p><a href="bt://${tempData.infoHash}/${file.path.replace(tempPath, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}">${file.name}</a></p>`})}</div></body></html>`]
-                                } else {
-                                    res.data = [JSON.stringify(tempData.files.map(file => {return 'bt://' + tempData.infoHash + '/' + file.path.replace(tempPath, '').split(path.sep).map(data => {return encodeURIComponent(data)}).join('/')}))]
-                                }
-                                res.statusCode = 200
-                                res.headers['Content-Type'] = req.mainRes
-                                res.headers['Content-Length'] = tempData.length
-                            } else {
-                                foundFile = tempData.files.find(file => {return file.path.endsWith(req.mainPath)})
-                                if(foundFile){
-                                    if(req.mainRange){
-                                        let ranges = parseRange(foundFile.length, req.mainRange)
-                                        if(ranges && ranges.length && ranges.type === 'bytes'){
-                                            let [{ start, end }] = ranges
-                                            let length = (end - start + 1)
-                                            req.mainPartial.start = start
-                                            req.mainPartial.end = end
-
-                                            res.headers['Content-Length'] = `${length}`
-                                            res.headers['Content-Range'] = `bytes ${start}-${end}/${foundFile.length}`
-                                        }
-                                        res.statusCode = 206
-                                        res.data = streamToIterator(foundFile.createReadStream(req.mainPartial))
-                                        res.headers['Content-Type'] = getMimeType(req.mainPath)
-                                    } else {
-                                        res.data = streamToIterator(foundFile.createReadStream())
-                                        res.headers['Content-Type'] = getMimeType(req.mainPath)
-                                        res.headers['Content-Length'] = foundFile.length
-                                        res.statusCode = 200
-                                    }
-                                } else {
-                                    res.data = [JSON.stringify('file was not found')]
-                                    res.statusCode = 400
-                                    res.headers['Content-Type'] = 'application/json; charset=utf-8'
-                                }
-                            }
-                        }
-                    }
-                  break
-                }
-                
-                case 'POST': {
-                    if(req.mainType){
-                        if(!body){
-                            if(req.mainReq){
-                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>body is required</p></div></body></html>`]
-                            } else {
-                                res.data = [JSON.stringify('body is required')]
-                            }
-                            res.statusCode = 400
-                        } else {
-                            if(body.folder){
-                                if(body.address === undefined || body.secret === undefined){
-                                    let {torrent, title} = await app.publishTitle(body.folder)
-                                    if(prog.has(torrent.infoHash)){
-                                        prog.delete(torrent.infoHash)
-                                        prog.set(torrent.infoHash, torrent)
-                                    } else {
-                                        prog.set(torrent.infoHash, torrent)
-                                    }
-                                    if(req.mainReq){
-                                        res.data = [`<html><head><title>${torrent.title}</title></head><body><div><p>infohash: ${torrent.infoHash}</p><p>folder: ${title}</p></div></body></html>`]
-                                    } else {
-                                        res.data = [JSON.stringify({infohash: torrent.infoHash, title})]
-                                    }
-                                    res.statusCode = 200
-                                } else {
-                                    let {torrent, secret} = await app.publishAddress(body.folder, {address: body.address, secret: body.secret})
-                                    if(prog.has(torrent.address)){
-                                        prog.delete(torrent.address)
-                                        prog.set(torrent.address, torrent)
-                                    } else {
-                                        prog.set(torrent.address, torrent)
-                                    }
-                                    if(req.mainReq){
-                                        res.data = [`<html><head><title>${torrent.address}</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p><p>sequence: ${torrent.sequence}</p><p>signature: ${torrent.sig}</p><p>magnet: ${torrent.magnet}</p><p>secret: ${secret}</p></div></body></html>`]
-                                    } else {
-                                        res.data = [JSON.stringify({address: torrent.address, infohash: torrent.infoHash, sequence: torrent.sequence, magnet: torrent.magnet, signature: torrent.sig, secret})]
-                                    }
-                                    res.statusCode = 200
-                                }
-                            } else {
-                                if(req.mainReq){
-                                    res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>body is missing data</p></div></body></html>`]
-                                } else {
-                                    res.data = [JSON.stringify('body is missing data')]
-                                }
-                                res.statusCode = 400
-                            }
-                        }
-                        res.headers['Content-Type'] = req.mainRes
-                    } else {
-                        if(req.mainQuery.length === 64){
-                            let torrent = await app.currentAddress(req.mainQuery)
-                            if(prog.has(torrent.address)){
-                                prog.delete(torrent.address)
-                                prog.set(torrent.address, torrent)
-                            } else {
-                                prog.set(torrent.address, torrent)
-                            }
-                            if(req.mainReq){
-                                res.data = [`<html><head><title>${torrent.address}</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p></div></body></html>`]
-                            } else {
-                                res.data = [JSON.stringify({address: torrent.address, infoHash: torrent.infoHash})]
-                            }
-                            res.statusCode = 200
-                        } else if(req.mainQuery.length === 32){
-                            let torrent = await app.currentTitle(req.mainQuery)
-                            if(prog.has(torrent.infoHash)){
-                                prog.delete(torrent.infoHash)
-                                prog.set(torrent.infoHash, torrent)
-                            } else {
-                                prog.set(torrent.infoHash, torrent)
-                            }
-                            if(req.mainReq){
-                                res.data = [`<html><head><title>${torrent.title}</title></head><body><div><p>title: ${torrent.title}</p><p>infohash: ${torrent.infoHash}</p></div></body></html>`]
-                            } else {
-                                res.data = [JSON.stringify({title: torrent.title, infoHash: torrent.infoHash})]
-                            }
-                            res.statusCode = 200
-                        }
-                        res.headers['Content-Type'] = req.mainRes
-                    }
-                    break
-                }
-
-                case 'DELETE': {
-                    if(req.mainType){
-                        if(!body){
-                            prog.clear()
-                            if(req.mainReq){
-                                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${app.clearData()}</p></div></body></html>`]
-                            } else {
-                                res.data = [JSON.stringify(app.clearData())]
-                            }
-                            res.statusCode = 400
-                            // mainData = [await app.clearData()]
-                            // prog.clear()
-                        } else if(body.hash){
-                            if(prog.has(body.hash)){
-                                prog.delete(body.hash)
-                            }
-                            if(req.mainReq){
-                                res.data = [`<html><head><title>${body.hash}</title></head><body><div><p>${await app.removeHash(body.hash)}</p></div></body></html>`]
-                            } else {
-                                res.data = [JSON.stringify(await app.removeHash(body.hash))]
-                            }
-                            res.statusCode = 200
-                        } else if(body.address){
-                            if(prog.has(body.address)){
-                                prog.delete(body.address)
-                            }
-                            if(req.mainReq){
-                                res.data = [`<html><head><title>${body.address}</title></head><body><div><p>${await app.removeAddress(body.address)}</p></div></body></html>`]
-                            } else {
-                                res.data = [JSON.stringify(await app.removeAddress(body.address))]
-                            }
-                            res.statusCode = 200
-                        } else if(body.title){
-                            if(prog.has(body.title)){
-                                prog.delete(body.title)
-                            }
-                            if(req.mainReq){
-                                res.data = [`<html><head><title>${body.title}</title></head><body><div><p>${await app.removeTitle(body.title)}</p></div></body></html>`]
-                            } else {
-                                res.data = [JSON.stringify(await app.removeTitle(body.title))]
-                            }
-                            res.statusCode = 200
-                        } else {
-                            res.data = [JSON.stringify('body is missing data')]
-                            res.statusCode = 400
-                        }
-                        res.headers['Content-Type'] = req.mainRes
-                    } else {
-                        if(req.mainQuery.length === 64){
-                            if(prog.has(req.mainQuery)){
-                                prog.delete(req.mainQuery)
-                            }
-                            if(req.mainReq){
-                                res.data = [`<html><head><title>${req.mainQuery}</title></head><body><div><p>${app.stopAddress(req.mainQuery)}</p></div></body></html>`]
-                            } else {
-                                res.data = [JSON.stringify(app.stopAddress(req.mainQuery))]
-                            }
-                            res.statusCode = 200
-                        } else if(req.mainQuery.length === 40){
-                            if(prog.has(req.mainQuery)){
-                                prog.delete(req.mainQuery)
-                            }
-                            if(req.mainReq){
-                                mainData = [`<html><head><title>${req.mainQuery}</title></head><body><div><p>${app.stopHash(req.mainQuery)}</p></div></body></html>`]
-                            } else {
-                                mainData = [JSON.stringify(app.stopHash(req.mainQuery))]
-                            }
-                            res.statusCode = 200
-                        } else if(req.mainQuery.length === 32){
-                            if(prog.has(req.mainQuery)){
-                                prog.delete(req.mainQuery)
-                            }
-                            if(req.mainReq){
-                                mainData = [`<html><head><title>${req.mainQuery}</title></head><body><div><p>${app.stopTitle(req.mainQuery)}</p></div></body></html>`]
-                            } else {
-                                mainData = [JSON.stringify(app.stopTitle(req.mainQuery))]
-                            }
-                            res.statusCode = 200
-                        }
-                        res.headers['Content-Type'] = req.mainRes
-                    }
-                    break
-                }
-              }
-              return res
-
-          } catch (e) {
-              return {statusCode: 500, headers: {}, data: [e.stack]}
-          }
-    })
-
-    async function getBody(body) {
-        let mainData = ''
-      
-        for await (const data of body) {
-          mainData += data
-        }
-      
-        return mainData
+      if (protocol !== 'bittorrent:') {
+        return {statusCode: 409, headers: {}, data: ['wrong protocol']}
+      } else if(!method || !SUPPORTED_METHODS.includes(method)){
+        return {statusCode: 409, headers: {}, data: ['something wrong with method']}
+      } else if((!hostname) || (hostname.length !== 1 && hostname.length !== 32 && hostname.length !== 40 && hostname.length !== 64) || (hostname.length === 1 && hostname !== hostType) || (hostname.length !== 1 && !checkTitle.test(hostname) && !checkHash.test(hostname) && !checkAddress.test(hostname))){
+        return {statusCode: 409, headers: {}, data: ['something wrong with hostname']}
       }
 
-      function getMimeType (path) {
-        let mimeType = mime.getType(path) || 'text/plain'
-        if (mimeType.startsWith('text/')) mimeType = `${mimeType}; charset=utf-8`
-        return mimeType
-      }      
+      const req = formatReq(hostname, pathname, method, searchParams, reqHeaders)
 
-    function formatReq(hostname, pathname, method, search, headers){
-        // let mainType = hostname[0] === hostType || hostname[0] === sideType ? hostname[0] : ''
-        let mainType = hostname[0] === hostType
-        let mainQuery = mainType ? hostname.replace(hostname[0], '') : hostname
-        let mainHost = hostname
-        // if(pathname){
-        //     console.log(decodeURIComponent(pathname))
-        // }
-        let mainPath = pathname ? decodeURIComponent(pathname).replace(/\//g, path.sep) : path.sep
-        let mainMethod = method
-        let mainReq = headers.accept && headers.accept.includes('text/html')
-        let mainRes = mainReq ? 'text/html; charset=utf-8' : 'application/json; charset=utf-8'
-        let mainReg = search.get('clear') ? true : false
-        let mainRange = headers.Range || headers.range
-        let mainPartial = {}
-        return {mainQuery, mainHost, mainPath, mainMethod, mainReg, mainReq, mainRes, mainType, mainRange, mainPartial}
-    }
-
-    fetch.destroy = () => {
-        return new Promise((resolve, reject) => {
-            app.webtorrent.destroy(error => {
-                if(error){
-                    reject(error)
+      const res = { statusCode: 400, headers: {}, data: [] }
+      switch (req.mainMethod) {
+        case 'HEAD': {
+          if (req.mainType) {
+            res.statusCode = 400
+            res.headers['Content-Length'] = 0
+          } else {
+            if (prog.has(req.mainQuery)) {
+              const torrentData = prog.get(req.mainQuery)
+              if (req.mainPath === path.sep) {
+                res.headers['Content-Type'] = req.mainRes
+                res.headers['Content-Length'] = `${torrentData.length}`
+                res.headers['Accept-Ranges'] = 'bytes'
+                res.headers['X-Downloaded'] = `${torrentData.downloaded}`
+                res.statusCode = 200
+              } else {
+                let tempPath = null
+                if (torrentData.files.length === 1 && torrentData.name === torrentData.files[0].name) {
+                  tempPath = torrentData.path + path.sep
                 } else {
-                    app.webproperty.clearData().then(res => {resolve(res)}).catch(error => {reject(error)})
+                  tempPath = torrentData.path + path.sep + torrentData.name + path.sep
                 }
-            })
-        })
+                const foundFile = torrentData.files.find(file => { file.path.replace(tempPath, '') === req.mainPath })
+                if (foundFile) {
+                  res.headers['Content-Type'] = getMimeType(req.mainPath)
+                  res.headers['Content-Length'] = `${foundFile.length}`
+                  res.headers['Accept-Ranges'] = 'bytes'
+                  res.headers['X-Downloaded'] = `${foundFile.downloaded}`
+                  res.statusCode = 200
+                } else {
+                  res.statusCode = 400
+                  res.headers['Content-Length'] = 0
+                }
+              }
+            } else {
+              res.statusCode = 400
+              res.headers['Content-Length'] = 0
+            }
+          }
+          break
+        }
+
+        case 'GET': {
+          if (req.mainType) {
+            if (req.mainReq) {
+              res.data = ['Thank you for using BT-Fetch']
+            } else {
+              res.data = [JSON.stringify('Thank you for using BT-Fetch')]
+            }
+            res.statusCode = 200
+            res.headers['Content-Type'] = req.mainRes
+          } else {
+            let torrentData = null
+            let foundFile = null
+            let tempPath = null
+            if (req.mainQuery.length === 64) {
+              if (prog.has(req.mainQuery)) {
+                torrentData = prog.get(req.mainQuery)
+              } else {
+                torrentData = await app.loadAddress(req.mainQuery)
+                prog.set(torrentData.address, torrentData)
+              }
+              if (torrentData.files.length === 1 && torrentData.name === torrentData.files[0].name) {
+                tempPath = torrentData.path + path.sep
+              } else {
+                tempPath = torrentData.path + path.sep + torrentData.name + path.sep
+              }
+              if (req.mainPath === path.sep) {
+                if (req.mainReq) {
+                  res.data = [`<html><head><title>${torrentData.address}</title></head><body><div>${torrentData.files.map(file => { return `<p><a href="/${file.path.replace(tempPath, '').split(path.sep).map(data => { return encodeURIComponent(data) }).join('/')}">${file.name}</a></p>` })}</div></body></html>`]
+                } else {
+                  res.data = [JSON.stringify(torrentData.files.map(file => { return `/${file.path.replace(tempPath, '').split(path.sep).map(data => { return encodeURIComponent(data) }).join('/')}` }))]
+                }
+                res.statusCode = 200
+                res.headers['Content-Type'] = req.mainRes
+                res.headers['Content-Length'] = torrentData.length
+              } else {
+                foundFile = torrentData.files.find(file => { file.path.replace(tempPath, '') === req.mainPath })
+                if (foundFile) {
+                  if (req.mainRange) {
+                    const ranges = parseRange(foundFile.length, req.mainRange)
+                    if (ranges && ranges.length && ranges.type === 'bytes') {
+                      const [{ start, end }] = ranges
+                      const length = (end - start + 1)
+
+                      res.data = streamToIterator(foundFile.createReadStream({start, end}))
+                      res.headers['Content-Length'] = `${length}`
+                      res.headers['Content-Range'] = `bytes ${start}-${end}/${foundFile.length}`
+                    }
+                    res.statusCode = 206
+                    res.headers['Content-Type'] = getMimeType(req.mainPath)
+                  } else {
+                    res.data = streamToIterator(foundFile.createReadStream())
+                    res.headers['Content-Type'] = getMimeType(req.mainPath)
+                    res.headers['Content-Length'] = foundFile.length
+                    res.statusCode = 200
+                  }
+                } else {
+                  res.data = [JSON.stringify('file was not found')]
+                  res.statusCode = 404
+                  res.headers['Content-Type'] = 'application/json; charset=utf-8'
+                }
+              }
+            } else if (req.mainQuery.length === 40) {
+              if (prog.has(req.mainQuery)) {
+                torrentData = prog.get(req.mainQuery)
+              } else {
+                torrentData = await app.loadHash(req.mainQuery)
+                prog.set(torrentData.infoHash, torrentData)
+              }
+              if (torrentData.files.length === 1 && torrentData.name === torrentData.files[0].name) {
+                tempPath = torrentData.path + path.sep
+              } else {
+                tempPath = torrentData.path + path.sep + torrentData.name + path.sep
+              }
+              if (req.mainPath === path.sep) {
+                if (req.mainReq) {
+                  res.data = [`<html><head><title>${torrentData.infoHash}</title></head><body><div>${torrentData.files.map(file => { return `<p><a href="/${file.path.replace(tempPath, '').split(path.sep).map(data => { return encodeURIComponent(data) }).join('/')}">${file.name}</a></p>` })}</div></body></html>`]
+                } else {
+                  res.data = [JSON.stringify(torrentData.files.map(file => { return `/${file.path.replace(tempPath, '').split(path.sep).map(data => { return encodeURIComponent(data) }).join('/')}` }))]
+                }
+                res.statusCode = 200
+                res.headers['Content-Type'] = req.mainRes
+                res.headers['Content-Length'] = torrentData.length
+              } else {
+                foundFile = torrentData.files.find(file => { file.path.replace(tempPath, '') === req.mainPath })
+                if (foundFile) {
+                  if (req.mainRange) {
+                    const ranges = parseRange(foundFile.length, req.mainRange)
+                    if (ranges && ranges.length && ranges.type === 'bytes') {
+                      const [{ start, end }] = ranges
+                      const length = (end - start + 1)
+                      req.mainPartial.start = start
+                      req.mainPartial.end = end
+
+                      res.headers['Content-Length'] = `${length}`
+                      res.headers['Content-Range'] = `bytes ${start}-${end}/${foundFile.length}`
+                    }
+                    res.statusCode = 206
+                    res.data = streamToIterator(foundFile.createReadStream(req.mainPartial))
+                    res.headers['Content-Type'] = getMimeType(req.mainPath)
+                  } else {
+                    res.data = streamToIterator(foundFile.createReadStream())
+                    res.headers['Content-Type'] = getMimeType(req.mainPath)
+                    res.headers['Content-Length'] = foundFile.length
+                    res.statusCode = 200
+                  }
+                } else {
+                  res.data = [JSON.stringify('file was not found')]
+                  res.statusCode = 404
+                  res.headers['Content-Type'] = 'application/json; charset=utf-8'
+                }
+              }
+            }
+          }
+          break
+        }
+
+        case 'POST': {
+          if (req.mainType) {
+            if (!body) {
+              if (req.mainReq) {
+                res.data = ['<html><head><title>BT-Fetch</title></head><body><div><p>body is required</p></div></body></html>']
+              } else {
+                res.data = [JSON.stringify('body is required')]
+              }
+              res.statusCode = 400
+            } else {
+              if (body.folder) {
+                if (body.address === undefined || body.secret === undefined) {
+                  const { torrent, title } = await app.publishTitle(body.folder)
+                  if (prog.has(torrent.infoHash)) {
+                    prog.delete(torrent.infoHash)
+                    prog.set(torrent.infoHash, torrent)
+                  } else {
+                    prog.set(torrent.infoHash, torrent)
+                  }
+                  if (req.mainReq) {
+                    res.data = [`<html><head><title>${torrent.title}</title></head><body><div><p>infohash: ${torrent.infoHash}</p><p>folder: ${title}</p></div></body></html>`]
+                  } else {
+                    res.data = [JSON.stringify({ infohash: torrent.infoHash, title })]
+                  }
+                  res.statusCode = 200
+                } else {
+                  const { torrent, secret } = await app.publishAddress(body.folder, { address: body.address, secret: body.secret })
+                  if (prog.has(torrent.address)) {
+                    prog.delete(torrent.address)
+                    prog.set(torrent.address, torrent)
+                  } else {
+                    prog.set(torrent.address, torrent)
+                  }
+                  if (req.mainReq) {
+                    res.data = [`<html><head><title>${torrent.address}</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p><p>sequence: ${torrent.sequence}</p><p>signature: ${torrent.sig}</p><p>magnet: ${torrent.magnet}</p><p>secret: ${secret}</p></div></body></html>`]
+                  } else {
+                    res.data = [JSON.stringify({ address: torrent.address, infohash: torrent.infoHash, sequence: torrent.sequence, magnet: torrent.magnet, signature: torrent.sig, secret })]
+                  }
+                  res.statusCode = 200
+                }
+              } else {
+                if (req.mainReq) {
+                  res.data = ['<html><head><title>BT-Fetch</title></head><body><div><p>body is missing data</p></div></body></html>']
+                } else {
+                  res.data = [JSON.stringify('body is missing data')]
+                }
+                res.statusCode = 400
+              }
+            }
+            res.headers['Content-Type'] = req.mainRes
+          } else {
+            if (req.mainQuery.length === 64) {
+              const torrent = await app.currentAddress(req.mainQuery)
+              if (prog.has(torrent.address)) {
+                prog.delete(torrent.address)
+                prog.set(torrent.address, torrent)
+              } else {
+                prog.set(torrent.address, torrent)
+              }
+              if (req.mainReq) {
+                res.data = [`<html><head><title>${torrent.address}</title></head><body><div><p>address: ${torrent.address}</p><p>infohash: ${torrent.infoHash}</p></div></body></html>`]
+              } else {
+                res.data = [JSON.stringify({ address: torrent.address, infoHash: torrent.infoHash })]
+              }
+              res.statusCode = 200
+            } else if (req.mainQuery.length === 32) {
+              const torrent = await app.currentTitle(req.mainQuery)
+              if (prog.has(torrent.infoHash)) {
+                prog.delete(torrent.infoHash)
+                prog.set(torrent.infoHash, torrent)
+              } else {
+                prog.set(torrent.infoHash, torrent)
+              }
+              if (req.mainReq) {
+                res.data = [`<html><head><title>${torrent.title}</title></head><body><div><p>title: ${torrent.title}</p><p>infohash: ${torrent.infoHash}</p></div></body></html>`]
+              } else {
+                res.data = [JSON.stringify({ title: torrent.title, infoHash: torrent.infoHash })]
+              }
+              res.statusCode = 200
+            }
+            res.headers['Content-Type'] = req.mainRes
+          }
+          break
+        }
+
+        case 'DELETE': {
+          if (req.mainType) {
+            if (!body) {
+              prog.clear()
+              if (req.mainReq) {
+                res.data = [`<html><head><title>BT-Fetch</title></head><body><div><p>${app.clearData()}</p></div></body></html>`]
+              } else {
+                res.data = [JSON.stringify(app.clearData())]
+              }
+              res.statusCode = 400
+              // mainData = [await app.clearData()]
+              // prog.clear()
+            } else if (body.hash) {
+              if (prog.has(body.hash)) {
+                prog.delete(body.hash)
+              }
+              if (req.mainReq) {
+                res.data = [`<html><head><title>${body.hash}</title></head><body><div><p>${await app.removeHash(body.hash)}</p></div></body></html>`]
+              } else {
+                res.data = [JSON.stringify(await app.removeHash(body.hash))]
+              }
+              res.statusCode = 200
+            } else if (body.address) {
+              if (prog.has(body.address)) {
+                prog.delete(body.address)
+              }
+              if (req.mainReq) {
+                res.data = [`<html><head><title>${body.address}</title></head><body><div><p>${await app.removeAddress(body.address)}</p></div></body></html>`]
+              } else {
+                res.data = [JSON.stringify(await app.removeAddress(body.address))]
+              }
+              res.statusCode = 200
+            } else if (body.title) {
+              if (prog.has(body.title)) {
+                prog.delete(body.title)
+              }
+              if (req.mainReq) {
+                res.data = [`<html><head><title>${body.title}</title></head><body><div><p>${await app.removeTitle(body.title)}</p></div></body></html>`]
+              } else {
+                res.data = [JSON.stringify(await app.removeTitle(body.title))]
+              }
+              res.statusCode = 200
+            } else {
+              res.data = [JSON.stringify('body is missing data')]
+              res.statusCode = 400
+            }
+            res.headers['Content-Type'] = req.mainRes
+          } else {
+            if (req.mainQuery.length === 64) {
+              if (prog.has(req.mainQuery)) {
+                prog.delete(req.mainQuery)
+              }
+              if (req.mainReq) {
+                res.data = [`<html><head><title>${req.mainQuery}</title></head><body><div><p>${app.stopAddress(req.mainQuery)}</p></div></body></html>`]
+              } else {
+                res.data = [JSON.stringify(app.stopAddress(req.mainQuery))]
+              }
+              res.statusCode = 200
+            } else if (req.mainQuery.length === 40) {
+              if (prog.has(req.mainQuery)) {
+                prog.delete(req.mainQuery)
+              }
+              if (req.mainReq) {
+                mainData = [`<html><head><title>${req.mainQuery}</title></head><body><div><p>${app.stopHash(req.mainQuery)}</p></div></body></html>`]
+              } else {
+                mainData = [JSON.stringify(app.stopHash(req.mainQuery))]
+              }
+              res.statusCode = 200
+            } else if (req.mainQuery.length === 32) {
+              if (prog.has(req.mainQuery)) {
+                prog.delete(req.mainQuery)
+              }
+              if (req.mainReq) {
+                mainData = [`<html><head><title>${req.mainQuery}</title></head><body><div><p>${app.stopTitle(req.mainQuery)}</p></div></body></html>`]
+              } else {
+                mainData = [JSON.stringify(app.stopTitle(req.mainQuery))]
+              }
+              res.statusCode = 200
+            }
+            res.headers['Content-Type'] = req.mainRes
+          }
+          break
+        }
+      }
+      return res
+    } catch (e) {
+      return { statusCode: 500, headers: {}, data: [e.stack] }
     }
+  })
 
-    return fetch
+  fetch.destroy = () => {
+    return new Promise((resolve, reject) => {
+      clearInterval(app.updateRoutine)
+      app.webtorrent.destroy(error => {
+        if (error) {
+          reject(error)
+        } else {
+          app.webproperty.clearData().then(res => { resolve(res) }).catch(error => { reject(error) })
+        }
+      })
+    })
+  }
 
+  return fetch
 }

--- a/main.js
+++ b/main.js
@@ -736,8 +736,8 @@ delayTimeOut(timeout, data, res){
       }
       function handleFiles(name, file, info){
         // fs.writeFile(path.join(folderPath, info.filename), Readable.from(file))
-        // const saveTo = fs.createWriteStream(path.join(folderPath, info.filename));
-        file.pipe(fs.createWriteStream(path.join(folderPath, info.filename)))
+        const saveTo = fs.createWriteStream(path.join(folderPath, info.filename))
+        file.pipe(saveTo)
       }
       function handleErrors(error){
         handleRemoval()

--- a/main.js
+++ b/main.js
@@ -7,8 +7,7 @@ const ed = require('ed25519-supercop')
 const bencode = require('bencode')
 const busboy = require('busboy')
 const { Readable } = require('stream')
-const EventIterator = require('event-iterator')
-const { fail } = require('assert')
+const {EventIterator} = require('event-iterator')
 // const EventEmitter = require('events').EventEmitter
 
 const BTPK_PREFIX = 'urn:btpk:'

--- a/main.js
+++ b/main.js
@@ -81,6 +81,7 @@ async function startUp(self){
                                 resolve(res)
                             }).catch(error => {
                                 console.log(error)
+                                // most likely the infohash of this torrent does not match what we have currently, stop this torrent
                                 self.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
                                 resolve(null)
                             })
@@ -381,7 +382,7 @@ class Main {
                     resolve(res)
                 }).catch(error => {
                     console.log(error)
-                    // if there is an error with publishing to the dht, then stop this torrent and reject the promise
+                    // most likely the infohash of this torrent does not match what we have, stop this torrent and reject the promise
                     this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
                     reject(error)
                 })

--- a/main.js
+++ b/main.js
@@ -108,9 +108,7 @@ async startUp () {
       const folderPath = path.join(this._internal, checkInternalPath)
       if (checkAddress.test(checkInternalPath)) {
         const checkTorrent = await Promise.any([
-          new Promise((resolve, reject) => {
-            setTimeout(() => { resolve(null) }, this._timeout)
-          }),
+          this.delayTimeOut(this._timeout, null, true),
           new Promise((resolve, reject) => {
             this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
               resolve(torrent)
@@ -120,7 +118,7 @@ async startUp () {
         if (checkTorrent) {
           checkTorrent.folder = folderPath
           const checkProperty = await Promise.any([
-            new Promise((resolve, reject) => { setTimeout(() => { resolve(null) }, this._timeout) }),
+            this.delayTimeOut(this._timeout, null, true),
             new Promise((resolve, reject) => {
               this.ownData(checkInternalPath, checkTorrent.infoHash).then(res => {
                 resolve(res)
@@ -145,9 +143,7 @@ async startUp () {
         }
       } else if (checkTitle.test(checkInternalPath)) {
         const checkTorrent = await Promise.any([
-          new Promise((resolve, reject) => {
-            setTimeout(() => { resolve(null) }, this._timeout)
-          }),
+          this.delayTimeOut(this._timeout, null, true),
           new Promise((resolve, reject) => {
             this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
               resolve(torrent)
@@ -173,7 +169,7 @@ async startUp () {
       const folderPath = path.join(this._external, checkExternalPath)
       if (checkAddress.test(checkExternalPath)) {
         const checkProperty = await Promise.any([
-          new Promise((resolve, reject) => { setTimeout(() => { resolve(null) }, this._timeout) }),
+          this.delayTimeOut(this._timeout, null, true),
           this.resolve(checkExternalPath)
         ])
         if (checkProperty) {
@@ -193,7 +189,7 @@ async startUp () {
             }
           }
           const checkTorrent = await Promise.any([
-            new Promise((resolve, reject) => { setTimeout(() => { resolve(null) }, this._timeout) }),
+            this.delayTimeOut(this._timeout, null, true),
             new Promise((resolve, reject) => {
               this.webtorrent.add(checkProperty.infoHash, { path: folderPath + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true }, torrent => {
                 resolve(torrent)
@@ -213,7 +209,7 @@ async startUp () {
         }
       } else if (checkHash.test(checkExternalPath)) {
         const checkTorrent = await Promise.any([
-          new Promise((resolve, reject) => { setTimeout(() => { resolve(null) }, this._timeout) }),
+          this.delayTimeOut(this._timeout, null, true),
           new Promise((resolve, reject) => {
             this.webtorrent.add(checkExternalPath, { path: folderPath, destroyStoreOnDestroy: true }, torrent => {
               resolve(torrent)
@@ -231,6 +227,23 @@ async startUp () {
       }
     }
   }
+}
+
+delayTimeOut(timeout, data, res){
+  return new Promise((resolve, reject) => {setTimeout(() => {if(res){resolve(data)} else {reject(data)}}, timeout)})
+  // if(res){
+  //   return new Promise((resolve, reject) => {
+  //     setTimeout(() => {
+  //       resolve(data)
+  //     }, timeout)
+  //   })
+  // } else {
+  //   return new Promise((resolve, reject) => {
+  //     setTimeout(() => {
+  //       reject(data)
+  //     }, timeout)
+  //   })
+  // }
 }
 
   // when we resume or seed a user created BEP46 torrent that has already been created before
@@ -349,9 +362,7 @@ async startUp () {
       throw new Error('folder does not exist')
     }
     checkTorrent = await Promise.race([
-      new Promise((resolve, reject) => {
-        setTimeout(() => { reject(new Error(title + ' took too long, it timed out')) }, this._timeout)
-      }),
+      this.delayTimeOut(this._timeout, new Error(title + ' took too long, it timed out'), false),
       new Promise((resolve, reject) => {
         this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
           resolve(torrent)
@@ -375,9 +386,7 @@ async startUp () {
       throw new Error('folder does not exist')
     }
     const checkTorrent = await Promise.race([
-      new Promise((resolve, reject) => {
-        setTimeout(() => { reject(new Error(address + ' took too long, it timed out')) }, this._timeout)
-      }),
+      this.delayTimeOut(this._timeout, new Error(address + ' took too long, it timed out'), false),
       new Promise((resolve, reject) => {
         this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
           resolve(torrent)
@@ -386,10 +395,10 @@ async startUp () {
     ])
     const checkProperty = await Promise.race([
       new Promise((resolve, reject) => {
-        setTimeout(() => {
+        this.delayTimeOut(this._timeout, new Error(address + ' property took too long, it timed out, please try again with only the keypair without the folder'), false).catch(error => {
           this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
-          reject(new Error(address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
-        }, this._timeout)
+          reject(error)
+        })
       }),
       new Promise((resolve, reject) => {
         this.ownData(address, checkTorrent.infoHash).then(res => {
@@ -426,9 +435,7 @@ async startUp () {
     //     console.log(error)
     // }
     checkTorrent = await Promise.race([
-      new Promise((resolve, reject) => {
-        setTimeout(() => { reject(new Error(hash + ' took too long, it timed out')) }, this._timeout)
-      }),
+      this.delayTimeOut(this._timeout, new Error(hash + ' took too long, it timed out'), false),
       new Promise((resolve, reject) => {
         this.webtorrent.add(hash, { path: folderPath, destroyStoreOnDestroy: true }, torrent => {
           resolve(torrent)
@@ -470,9 +477,7 @@ async startUp () {
       await fs.copy(folder.oldFolder, folder.newFolder, { overwrite: true })
     }
     const checkTorrent = await Promise.race([
-      new Promise((resolve, reject) => {
-        setTimeout(() => { reject(new Error('torrent took too long, it timed out')) }, this._timeout)
-      }),
+      this.delayTimeOut(this._timeout, new Error('torrent took too long, it timed out'), false),
       new Promise((resolve, reject) => {
         this.webtorrent.seed(folder.main, { destroyStoreOnDestroy: true }, torrent => {
           resolve(torrent)
@@ -492,9 +497,7 @@ async startUp () {
       return haveTorrent
     }
     const checkProperty = await Promise.race([
-      new Promise((resolve, reject) => {
-        setTimeout(() => { reject(new Error(address + ' property took too long, it timed out')) }, this._timeout)
-      }),
+      this.delayTimeOut(this._timeout, new Error(address + ' property took too long, it timed out'), false),
       this.resolveFunc(address)
     ])
 
@@ -522,9 +525,7 @@ async startUp () {
     }
 
     const checkTorrent = await Promise.race([
-      new Promise((resolve, reject) => {
-        setTimeout(() => { reject(new Error(checkProperty.address + ' took too long, it timed out')) }, this._timeout)
-      }),
+      this.delayTimeOut(this._timeout, new Error(checkProperty.address + ' took too long, it timed out'), false),
       new Promise((resolve, reject) => {
         this.webtorrent.add(checkProperty.infoHash, { path: checkProperty.folder + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true }, torrent => {
           resolve(torrent)
@@ -570,9 +571,7 @@ async startUp () {
       await fs.copy(folder.oldFolder, folder.newFolder, { overwrite: true })
     }
     const checkTorrent = await Promise.race([
-      new Promise((resolve, reject) => {
-        setTimeout(() => { reject(new Error('torrent took too long, it timed out')) }, this._timeout)
-      }),
+      this.delayTimeOut(this._timeout, new Error('torrent took too long, it timed out'), false),
       new Promise((resolve, reject) => {
         this.webtorrent.seed(folder.main, { destroyStoreOnDestroy: true }, torrent => {
           resolve(torrent)
@@ -581,10 +580,10 @@ async startUp () {
     ])
     const checkProperty = await Promise.race([
       new Promise((resolve, reject) => {
-        setTimeout(() => {
+        this.delayTimeOut(this._timeout, new Error(keypair.address + ' property took too long, it timed out, please try again with only the keypair without the folder'), false).catch(error => {
           this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
-          reject(new Error(keypair.address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
-        }, this._timeout)
+          reject(error)
+        })
       }),
       new Promise((resolve, reject) => {
         this.publishFunc(keypair.address, keypair.secret, { ih: checkTorrent.infoHash }).then(res => {

--- a/main.js
+++ b/main.js
@@ -740,24 +740,24 @@ delayTimeOut(timeout, data, res){
       function handleRemoval(){
         bb.off('file', handleFiles)
         bb.off('error', handleErrors)
-        bb.off('close', handleClose)
+        bb.off('close', handleFinish)
       }
       function handleFiles(name, file, info){
         // fs.writeFile(path.join(folderPath, info.filename), Readable.from(file))
         // const saveTo = fs.createWriteStream(path.join(folderPath, info.filename))
-        file.pipe(fs.createWriteStream(path.join(folderPath, info.filename)))
+        Readable.from(file).pipe(fs.createWriteStream(path.join(folderPath, info.filename)))
       }
       function handleErrors(error){
         handleRemoval()
         reject(error)
       }
-      function handleClose(){
+      function handleFinish(){
         handleRemoval()
         resolve(null)
       }
       bb.on('file', handleFiles)
       bb.on('error', handleErrors)
-      bb.on('close', handleClose)
+      bb.on('finish', handleFinish)
       Readable.from(data).pipe(bb)
     })
   }

--- a/main.js
+++ b/main.js
@@ -22,897 +22,907 @@ function encodeSigData (msg) {
 const checkHash = new RegExp('^[a-fA-F0-9]{40}$')
 const checkAddress = new RegExp('^[a-fA-F0-9]{64}$')
 const checkTitle = new RegExp('^[a-f0-9]{32}$')
-const defOpts = {folder: __dirname, storage: 'storage', author: 'author', external: 'external', internal: 'internal', timeout: 60000, share: false, current: true, initial: true}
-
-// keep data active in the dht, runs every hour
-async function keepUpdated(self){
-    self._readyToGo = false
-    for(let i = 0;i < self.webtorrent.torrents.length;i++){
-        if(self.webtorrent.torrents[i].address){
-            try {
-                await self.bothGetPut(self.webtorrent.torrents[i])
-            } catch (error) {
-                console.log(error)
-            }
-            await new Promise((resolve, reject) => setTimeout(resolve, 5000))
-        }
-    }
-    self._readyToGo = true
-}
-
-//-------------------------------------
-// start up functions runs on every start up
-//-------------------------------------------
-async function startUp(self){
-    // a mechanism to clear all data meaning delete all user-created torrents, all non-user created torrents, and all BEP46 publishing data, most likely too extreme and not needed
-
-    // if(self._status.clear){
-    //     try {
-    //         await fs.emptyDir(self._external)
-    //         await fs.emptyDir(self._internal)
-    //         await fs.emptyDir(self._author)
-    //     } catch (error) {
-    //         console.log(error)
-    //     }
-    // }
-
-    // if initial option is true, then start seeding all user created torrents on start up
-    if(self._status.initial){
-        let checkInternal = await fs.readdir(self._internal, {withFileTypes: false})
-        for(let i = 0;i < checkInternal.length;i++){
-            let folderPath = self._internal + path.sep + checkInternal[i]
-            if(checkAddress.test(checkInternal[i])){
-                let checkTorrent = await Promise.any([
-                    new Promise((resolve, reject) => {
-                        setTimeout(() => {resolve(null)}, self._status.timeout)
-                    }),
-                    new Promise((resolve, reject) => {
-                        self.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
-                            resolve(torrent)
-                        })
-                    })
-                ])
-                if(checkTorrent){
-                    checkTorrent.folder = folderPath
-                    let checkProperty = await Promise.any([
-                        new Promise((resolve, reject) => {setTimeout(() => {resolve(null)}, self._status.timeout)}),
-                        new Promise((resolve, reject) => {
-                            self.ownData(checkInternal[i], checkTorrent.infoHash).then(res => {
-                                resolve(res)
-                            }).catch(error => {
-                                console.log(error)
-                                // most likely the infohash of this torrent does not match what we have currently, stop this torrent
-                                self.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-                                resolve(null)
-                            })
-                        })
-                    ])
-                    if(checkProperty){
-                        // don't overwrite the torrent's infohash even though they will both be the same
-                        delete checkProperty.infoHash
-                        for(const prop in checkProperty){
-                            checkTorrent[prop] = checkProperty[prop]
-                        }
-                        checkTorrent.folder = folderPath
-                        checkTorrent.side = true
-                        console.log(checkInternal[i] + ' is good')
-                    }
-                }
-            } else if(checkTitle.test(checkInternal[i])){
-                let checkTorrent = await Promise.any([
-                    new Promise((resolve, reject) => {
-                        setTimeout(() => {resolve(null)}, self._status.timeout)
-                    }),
-                    new Promise((resolve, reject) => {
-                        self.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
-                            resolve(torrent)
-                        })
-                    })
-                ])
-                if(checkTorrent){
-                    checkTorrent.folder = folderPath
-                    checkTorrent.title = checkInternal[i]
-                    checkTorrent.side = true
-                    console.log(checkInternal[i] + ' is good')
-                }
-            } else {
-                await fs.remove(folderPath)
-            }
-        }
-    }
-
-    // if share option is true, then start seeding(webtorrent.add seeds after torrent is downloaded) on start up
-    if(self._status.share){
-        let checkExternal = await fs.readdir(self._external, {withFileTypes: false})
-        for(let i = 0;i < checkExternal.length;i++){
-            let folderPath = self._external + path.sep + checkExternal[i]
-            if(checkAddress.test(checkExternal[i])){
-                let checkProperty = await Promise.any([
-                    new Promise((resolve, reject) => {setTimeout(() => {resolve(null)}, self._status.timeout)}),
-                    self.resolve(checkExternal[i])
-                ])
-                if(checkProperty){
-                    if(self._status.current){
-                        if(!await fs.pathExists(folderPath + path.sep + checkProperty.infoHash)){
-                            try {
-                                await fs.emptyDir(folderPath)
-                            } catch (error) {
-                                console.log(error)
-                            }
-                        }
-                    } else if(!self._status.current){
-                        try {
-                            await fs.ensureDir(folderPath)
-                        } catch (error) {
-                            console.log(error)
-                        }
-                    }
-                    let checkTorrent = await Promise.any([
-                        new Promise((resolve, reject) => {setTimeout(() => {resolve(null)}, self._status.timeout)}),
-                        new Promise((resolve, reject) => {
-                            self.webtorrent.add(checkProperty.infoHash, {path: folderPath + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true}, torrent => {
-                                resolve(torrent)
-                            })
-                        })
-                    ])
-                    if(checkTorrent){
-                        checkTorrent.folder = folderPath
-                        checkTorrent.side = false
-                        // don't overwrite the torrent's infohash even though they will both be the same
-                        delete checkProperty.infoHash
-                        for(const prop in checkProperty){
-                            checkTorrent[prop] = checkProperty[prop]
-                        }
-                        console.log(checkExternal[i] + ' is good')
-                    }
-                }
-            } else if(checkHash.test(checkExternal[i])){
-                let checkTorrent = await Promise.any([
-                    new Promise((resolve, reject) => {setTimeout(() => {resolve(null)}, self._status.timeout)}),
-                    new Promise((resolve, reject) => {
-                        self.webtorrent.add(checkExternal[i], {path: folderPath, destroyStoreOnDestroy: true}, torrent => {
-                            resolve(torrent)
-                        })
-                    })
-                ])
-                if(checkTorrent){
-                    checkTorrent.folder = folderPath
-                    checkTorrent.side = false
-                    checkTorrent.title = crypto.createHash('md5').update(checkExternal[i]).digest("hex")
-                    console.log(checkExternal[i] + ' is good')
-                }
-            } else {
-                await fs.remove(folderPath)
-            }
-        }
-    }
-}
+const defOpts = { folder: __dirname, storage: 'storage', author: 'author', external: 'external', internal: 'internal', timeout: 60000, share: false, current: true, initial: true }
 
 class Main {
-    constructor(opts = {}){
-        const finalOpts = {...defOpts, ...opts}
-        finalOpts.folder = path.resolve(finalOpts.folder)
-        fs.ensureDirSync(finalOpts.folder)
+  constructor (opts = {}) {
+    const finalOpts = { ...defOpts, ...opts }
+    this._current = finalOpts.current
+    this._share = finalOpts.share
+    this._timeout = finalOpts.timeout
+    this._initial = finalOpts.initial
 
-        this._status = {current: finalOpts.current, share: finalOpts.share, timeout: finalOpts.timeout, initial: finalOpts.initial}
-        this._storage = finalOpts.folder + path.sep + finalOpts.storage
-        this._external = this._storage + path.sep + finalOpts.external
-        this._internal = this._storage + path.sep + finalOpts.internal
-        this._author = finalOpts.folder + path.sep + finalOpts.author
-        if(!fs.pathExistsSync(this._storage)){
-            fs.ensureDirSync(this._storage)
-        }
-        if(!fs.pathExistsSync(this._external)){
-            fs.ensureDirSync(this._external)
-        }
-        if(!fs.pathExistsSync(this._internal)){
-            fs.ensureDirSync(this._internal)
-        }
-        if(!fs.pathExistsSync(this._author)){
-            fs.ensureDirSync(this._author)
-        }
-        this.webtorrent = new WebTorrent({dht: {verify: ed.verify}})
-        this.webtorrent.on('error', error => {
-            console.log(error)
-        })
-        this._readyToGo = true
+    finalOpts.folder = path.resolve(finalOpts.folder)
+    fs.ensureDirSync(finalOpts.folder)
 
-        // run the start up function
-        startUp(this).catch(error => {console.log(error)})
-
-        // run the keepUpdated function every 1 hour, it keep the data active by putting the data back into the dht, don't run it if it is still working from the last time it ran the keepUpdated function
-        setInterval(() => {
-            if(this._readyToGo){
-                keepUpdated(this).catch(error => {console.log(error)})
-            }
-        }, 3600000)
+    this._folder = finalOpts.folder
+    this._storage = this._folder + path.sep + finalOpts.storage
+    this._external = this._storage + path.sep + finalOpts.external
+    this._internal = this._storage + path.sep + finalOpts.internal
+    this._author = this._folder + path.sep + finalOpts.author
+    if (!fs.pathExistsSync(this._storage)) {
+      fs.ensureDirSync(this._storage)
     }
+    if (!fs.pathExistsSync(this._external)) {
+      fs.ensureDirSync(this._external)
+    }
+    if (!fs.pathExistsSync(this._internal)) {
+      fs.ensureDirSync(this._internal)
+    }
+    if (!fs.pathExistsSync(this._author)) {
+      fs.ensureDirSync(this._author)
+    }
+    this.webtorrent = new WebTorrent({ dht: { verify: ed.verify } })
+    this.webtorrent.on('error', error => {
+      console.log(error)
+    })
+    this._readyToGo = true
 
-    // when we resume or seed a user created BEP46 torrent that has already been created before
-    // we have to check that the infohash of the torrent(remember we do not know the infohash before) matches the signature
-    // if it does not match, that means the data/torrent has been corrupted somehow
-    async ownData(address, infoHash){
-        if(!await fs.pathExists(this._author + path.sep + address)){
-            throw new Error('data was not found')
-        }
-        let data = await fs.readFile(this._author + path.sep + address)
-        data = JSON.parse(data.toString())
-        if(infoHash !== data.infoHash || !ed.verify(Buffer.from(data.sig, 'hex'), encodeSigData({seq: data.sequence, v: {ih: infoHash, ...data.stuff}}), Buffer.from(data.address, 'hex'))){
-          throw new Error('data does not match signature')
-        }
-        return data
+    // run the start up function
+    this.startUp().catch(error => { console.log(error) })
+
+    // run the keepUpdated function every 1 hour, it keep the data active by putting the data back into the dht, don't run it if it is still working from the last time it ran the keepUpdated function
+    this.updateRoutine = setInterval(() => {
+      if (this._readyToGo) {
+        this.keepUpdated().catch(error => { console.log(error) })
       }
+    }, 3600000)
+  }
 
-      // resolve public key address to an infohash
-      async resolveFunc(address){
-        if(!address || typeof(address) !== 'string'){
-            throw new Error('address can not be parsed')
-        }
-        const addressKey = Buffer.from(address, 'hex')
-        let getData = await new Promise((resolve, reject) => {
-            sha1(addressKey, (targetID) => {
-                this.webtorrent.dht.get(targetID, (err, res) => {
-                    if(err){
-                        reject(err)
-                    } else if(res){
-                        resolve(res)
-                    } else if(!res){
-                        reject(new Error('Could not resolve address'))
-                    }
-                })
-            })
-        })
-        if(!checkHash.test(getData.v.ih.toString('utf-8')) || !Number.isInteger(getData.seq)){
-            throw new Error('data is invalid')
-        }
-        for(const prop in getData.v){
-            getData.v[prop] = getData.v[prop].toString('utf-8')
-        }
-        let {ih, ...stuff} = getData.v
-        return {magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: getData.seq, stuff, sig: getData.sig.toString('hex'), side: false, from: getData.id.toString('hex')}
+// keep data active in the dht, runs every hour
+async keepUpdated () {
+  this._readyToGo = false
+  for (const torrent of this.webtorrent.torrents) {
+    if (torrent.address) {
+      try {
+        await this.bothGetPut(torrent)
+      } catch (error) {
+        console.log(error)
       }
-
-      // publish an infohash under a public key address in the dht
-      async publishFunc(address, secret, text){
-            for(let prop in text){
-              if(typeof(text[prop]) !== 'string'){
-                throw new Error('text data must be strings')
-              }
-            }
-            if(!checkHash.test(text.ih)){
-              throw new Error('must have infohash')
-            }
-            if(!address || !secret){
-              throw new Error('must have address and secret')
-            }
-        
-            const buffAddKey = Buffer.from(address, 'hex')
-            const buffSecKey = secret ? Buffer.from(secret, 'hex') : null
-            const v = text
-      
-            let main = null
-            let seq = null
-            if(await fs.pathExists(this._author + path.sep + address)){
-              main = await fs.readFile(this._author + path.sep + address)
-              main = JSON.parse(data.toString())
-              seq = main.sequence + 1
-            } else {
-              seq = 0
-            }
-
-            const buffSig = ed.sign(encodeSigData({seq, v}), buffAddKey, buffSecKey)
-            
-            let putData = await new Promise((resolve, reject) => {
-                this.webtorrent.dht.put({k: buffAddKey, v, seq, sig: buffSig}, (putErr, hash, number) => {
-                    if(putErr){
-                        reject(putErr)
-                    } else {
-                        resolve({hash: hash.toString('hex'), number})
-                    }
-                })
-            })
-            let {ih, ...stuff} = text
-            main = {magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: seq, stuff, sig: buffSig.toString('hex'), side: true, ...putData}
-            await fs.writeFile(this._author + path.sep + address, JSON.stringify(main))
-            return main
-      }
-
-    // async shred(address){
-    //     if(await fs.pathExists(this._author + path.sep + address)){
-    //       await fs.remove(this._author + path.sep + address)
-    //       return true
-    //     } else {
-    //       return false
-    //     }
-    //   }
-
-    // we use this function to seed a non-BEP46 torrent that we have already created before, not really needed but here just for consistency
-    async currentTitle(title){
-        let haveTorrent = this.findTheTitle(title)
-        if(haveTorrent){
-            return haveTorrent
-        }
-        let folderPath = this._internal + path.sep + title
-        if(!await fs.pathExists(folderPath)){
-            throw new Error('folder does not exist')
-        }
-        checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error(title + ' took too long, it timed out'))}, this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        checkTorrent.folder = folderPath
-        checkTorrent.title = title
-        checkTorrent.side = true
-        return checkTorrent
+      await new Promise((resolve, reject) => setTimeout(resolve, 5000))
     }
+  }
+  this._readyToGo = true
+}
 
-    // we must use this function to seed a BEP46 torrent that we have already published before
-    async currentAddress(address){
-        let haveTorrent = this.findTheAddress(address)
-        if(haveTorrent){
-            return haveTorrent
-        }
-        let folderPath = this._internal + path.sep + address
-        if(!await fs.pathExists(folderPath)){
-            throw new Error('folder does not exist')
-        }
-        let checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error(address + ' took too long, it timed out'))}, this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        let checkProperty = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-                    reject(new Error(address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
-                },this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.ownData(address, checkTorrent.infoHash).then(res => {
-                    resolve(res)
-                }).catch(error => {
-                    console.log(error)
-                    // most likely the infohash of this torrent does not match what we have, stop this torrent and reject the promise
-                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-                    reject(error)
-                })
-            })
-        ])
-        // don't overwrite the torrent's infohash even though they will both be the same
-        delete checkProperty.infoHash
-        checkProperty.folder = folderPath
-        checkProperty.side = true
-        for(const prop in checkProperty){
-            checkTorrent[prop] = checkProperty[prop]
-        }
-        return checkTorrent
-    }
+// -------------------------------------
+// start up functions runs on every start up
+// -------------------------------------------
+async startUp () {
+  // a mechanism to clear all data meaning delete all user-created torrents, all non-user created torrents, and all BEP46 publishing data, most likely too extreme and not needed
 
-    // download a regular non-BEP46 non-user created torrent by entering a 40 character infohash
-    async loadHash(hash){
-        let haveTorrent = this.findTheHash(hash)
-        if(haveTorrent){
-            return haveTorrent
-        }
-        // if user had torrent before, then empty the folder so previous data does not conflict with the infohash
-        let folderPath = this._external + path.sep + hash
-        // try {
-        //     await fs.emptyDir(folderPath)
-        // } catch (error) {
-        //     console.log(error)
-        // }
-        checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error(hash + ' took too long, it timed out'))}, this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.add(hash, {path: folderPath, destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        checkTorrent.folder = folderPath
-        checkTorrent.side = false
-        checkTorrent.title = crypto.createHash('md5').update(hash).digest("hex")
-        return checkTorrent
-    }
+  // if(this._clear){
+  //     try {
+  //         await fs.emptyDir(this._external)
+  //         await fs.emptyDir(this._internal)
+  //         await fs.emptyDir(this._author)
+  //     } catch (error) {
+  //         console.log(error)
+  //     }
+  // }
 
-    // publish a regular non-BEP46 torrent, we need a path to the directory where the data is
-    // we copy it to a new sub-directory(inside the this._internal directory)
-    // that will have a 32 character md5 hash as it's sub-directory name
-    // we do this because we can not name it with the infohash
-    // because we do not know the infohash of this torrent beforehand
-    // we return the torrent along with the title
-    // that way the user knows the title when they want to start the torrent
-    async publishTitle(folder){
-        if(!folder || typeof(folder) !== 'string'){
-            throw new Error('path ' + folder + ' does not work')
-        } else {
-            folder = {oldFolder: path.resolve(folder)}
-            folder.target = path.basename(folder.oldFolder)
-            folder.hashed = crypto.createHash('md5').update(folder.oldFolder).digest("hex")
-            folder.main = this._internal + path.sep + folder.hashed
-            folder.newFolder = folder.target.includes('.') ? folder.main + path.sep + folder.target : folder.main
-            let haveTorrent = this.findTheTitle(folder.hashed)
-            if(haveTorrent){
-                return {torrent: haveTorrent, title: haveTorrent.title}
-            }
-            if(folder.target.includes('.')){
-                try {
-                    await fs.emptyDir(folder.main)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            await fs.copy(folder.oldFolder, folder.newFolder, {overwrite: true})
-        }
-        let checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error('torrent took too long, it timed out'))}, this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.seed(folder.main, {destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        checkTorrent.folder = folder.main
-        checkTorrent.title = folder.hashed
-        checkTorrent.side = true
-        return {torrent: checkTorrent, title: checkTorrent.title}
-    }
-
-    // download a non-user created BEP46 torrent by their public key address, non-user meaning someone else's BEP46 torrent
-    async loadAddress(address){
-        let haveTorrent = this.findTheAddress(address)
-        if(haveTorrent){
-            return haveTorrent
-        }
-        let checkProperty = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error(address + ' property took too long, it timed out'))}, this._status.timeout)
-            }),
-            this.resolveFunc(address)
-        ])
-
-        checkProperty.folder = this._external + path.sep + checkProperty.address
-        checkProperty.side = false
-
-        // if current option is true, then if the infohash for the address is brand new then empty the directory and download the new infohash
-        // if the current option is false, then at least make sure the main folder which is named with the public key address exists
-        if(this._status.current){
-            if(!await fs.pathExists(checkProperty.folder + path.sep + checkProperty.infoHash)){
-                try {
-                    await fs.emptyDir(checkProperty.folder)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        } else if(!this._status.current){
-            if(!await fs.pathExists(checkProperty.folder)){
-                try {
-                    await fs.ensureDir(checkProperty.folder)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        }
-
-        let checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error(checkProperty.address + ' took too long, it timed out'))}, this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.add(checkProperty.infoHash, {path: checkProperty.folder + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        // don't overwrite the torrent's infohash even though they will both be the same
-        delete checkProperty.infoHash
-        for(const prop in checkProperty){
-            checkTorrent[prop] = checkProperty[prop]
-        }
-        return checkTorrent
-    }
-
-    // publish a new BEP46 torrent, or update an address/public key with a new torrent
-    // we need a folder(string) passed in as an argument
-    // we check we have a torrent already for the public key address
-    // we then copy the data from the folder to the this._internal directory
-    // we return secret key along with the torrent because the user will need it
-    async publishAddress(folder, keypair){
-        if(!keypair || !keypair.address || !keypair.secret){
-            keypair = this.createKeypair()
-        } else {
-            let haveTorrent = this.findTheAddress(keypair.address)
-            if(haveTorrent){
-                return {torrent: haveTorrent, secret: null}
-            }
-        }
-        if(!folder || typeof(folder) !== 'string'){
-            throw new Error('must have folder')
-        } else {
-            folder = {oldFolder: path.resolve(folder)}
-            folder.main = this._internal + path.sep + keypair.address
-            folder.target = path.basename(folder.oldFolder)
-            folder.newFolder = folder.target.includes('.') ? folder.main + path.sep + folder.target : folder.main
-            if(folder.target.includes('.')){
-                try {
-                    await fs.emptyDir(folder.main)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            await fs.copy(folder.oldFolder, folder.newFolder, {overwrite: true})
-        }
-        let checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error('torrent took too long, it timed out'))},this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.seed(folder.main, {destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        let checkProperty = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-                    reject(new Error(keypair.address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
-                },this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.publishFunc(keypair.address, keypair.secret, {ih: checkTorrent.infoHash}).then(res => {
-                    resolve(res)
-                }).catch(error => {
-                    // if there is an error with publishing to the dht, then stop this torrent and reject the promise
-                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-                    reject(error)
-                })
-            })
-        ])
-        // don't overwrite the torrent's infohash even though they will both be the same
-        delete checkProperty.infoHash
-        checkProperty.folder = folder.main
-        checkProperty.side = true
-        for(const prop in checkProperty){
-            checkTorrent[prop] = checkProperty[prop]
-        }
-        return {torrent: checkTorrent, secret: keypair.secret}
-    }
-    
-    // ------------- the below functions are for stopping or removing data and torrents
-
-    // stops all torrents
-    clearData(){
-        for(let i = 0;i < this.webtorrent.torrents.length;i++){
-            this.webtorrent.remove(this.webtorrent.torrents[i].infoHash, {destroyStore: false})
-        }
-        return 'data was stopped'
-    }
-
-    // stops the torrent with the title(string), title is a 32 character md5 hash used for the directory name of a non-BEP46 user created torrent aka regular torrent
-    stopTitle(title){
-        let checkTorrent = this.findTheTitle(title)
-        if(checkTorrent){
-            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-            return title + ' was stopped'
-        } else {
-            return title + ' was not found'
-        }
-    }
-
-    // stops the torrent with the 40 character infohash(string)
-    stopHash(hash){
-        let checkTorrent = this.findTheHash(hash)
-        if(checkTorrent){
-            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-            return hash + ' was stopped'
-        } else {
-            return hash + ' was not found'
-        }
-    }
-
-    // stops the torrent with the 64 character public key(string)
-    stopAddress(address){
-        let checkTorrent = this.findTheAddress(address)
-        if(checkTorrent){
-            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-            return address + ' was stopped'   
-        } else {
-            return address + ' was not found'
-        }
-    }
-
-    // stop the torrent with the title, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
-    async removeTitle(title){
-        let checkTorrent = this.findTheTitle(title)
-        if(checkTorrent){
-            let folder = checkTorrent.folder
-            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-            if(folder){
-                try {
-                    await fs.remove(folder)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        } else {
-            if(await fs.pathExists(this._external + path.sep + title)){
-                try {
-                    await fs.remove(this._external + path.sep + title)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            if(await fs.pathExists(this._internal + path.sep + title)){
-                try {
-                    await fs.remove(this._internal + path.sep + title)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        }
-        return title + ' has been removed'
-    }
-
-    // stop the torrent with the infohash, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
-    async removeHash(hash){
-        let checkTorrent = this.findTheHash(hash)
-        if(checkTorrent){
-            let folder = checkTorrent.folder
-            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-            if(folder){
-                try {
-                    await fs.remove(folder)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        } else {
-            if(await fs.pathExists(this._external + path.sep + hash)){
-                try {
-                    await fs.remove(this._external + path.sep + hash)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            if(await fs.pathExists(this._internal + path.sep + hash)){
-                try {
-                    await fs.remove(this._internal + path.sep + hash)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        }
-        return hash + ' has been removed'
-    }
-
-    // stop the torrent with the address, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
-    async removeAddress(address){
-        let checkedTorrent = this.findTheAddress(address)
-        if(checkedTorrent){
-            let folder = checkedTorrent.folder
-            let side = checkedTorrent.side
-            this.webtorrent.remove(checkedTorrent.infoHash, {destroyStore: false})
-            if(folder){
-                try {
-                    await fs.remove(folder)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            if(side){
-                try {
-                    await fs.remove(this._author + path.sep + address)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        } else {
-            if(await fs.pathExists(this._external + path.sep + address)){
-                try {
-                    await fs.remove(this._external + path.sep + address)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            if(await fs.pathExists(this._internal + path.sep + address)){
-                try {
-                    await fs.remove(this._internal + path.sep + address)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            if(await fs.pathExists(this._author + path.sep + address)){
-                await fs.remove(this._author + path.sep + address)
-              }
-        }
-        return address + ' was removed'
-    }
-
-    // --------------------- the below functions loops and gets the torrents we are seeking, if it is not found then null is returned
-    findTheFolder(folder){
-        let tempTorrent = null
-        for(let i = 0;i < this.webtorrent.torrents.length;i++){
-            if(this.webtorrent.torrents[i].folder === folder){
-                tempTorrent = this.webtorrent.torrents[i]
-                break
-            }
-        }
-        return tempTorrent
-    }
-    findTheTitle(title){
-        let tempTorrent = null
-        for(let i = 0;i < this.webtorrent.torrents.length;i++){
-            if(this.webtorrent.torrents[i].title === title){
-                tempTorrent = this.webtorrent.torrents[i]
-                break
-            }
-        }
-        return tempTorrent
-    }
-    findTheHash(hash){
-        let tempTorrent = null
-        for(let i = 0;i < this.webtorrent.torrents.length;i++){
-            if(this.webtorrent.torrents[i].infoHash === hash){
-                tempTorrent = this.webtorrent.torrents[i]
-                break
-            }
-        }
-        return tempTorrent
-    }
-    findTheAddress(address){
-        let tempTorrent = null
-        for(let i = 0;i < this.webtorrent.torrents.length;i++){
-            if(this.webtorrent.torrents[i].address === address){
-                tempTorrent = this.webtorrent.torrents[i]
-                break
-            }
-        }
-        return tempTorrent
-    }
-
-    // -------------- the below functions are BEP46 helpders, especially bothGetPut which keeps the data active in the dht ----------------
-
-    // this function is used to keep data active in the dht
-    // torrent data is passed in as an argument
-    // it gets the most recent data from another user in the dht
-    // then puts that most recent data back into the dht
-    // if it  can not get the most recent data from another user
-    // then we put the torrent data that we currently have back into the dht
-    bothGetPut(data){
-        return new Promise((resolve, reject) => {
-          const buffAddKey = Buffer.from(data.address, 'hex')
-          const buffSigData = Buffer.from(data.sig, 'hex')
-          sha1(buffAddKey, (targetID) => {
-      
-            this.webtorrent.dht.get(targetID, (getErr, getData) => {
-              if(getErr){
-                console.log(getErr)
-              }
-              if(getData){
-                this.webtorrent.dht.put(getData, (putErr, hash, number) => {
-                  if(putErr){
-                    reject(putErr)
-                  } else {
-                    resolve({getData, putData: {hash: hash.toString('hex'), number}})
-                  }
-                })
-              } else if(!getData){
-                this.webtorrent.dht.put({k: buffAddKey, v: {ih: data.infoHash, ...data.stuff}, seq: data.sequence, sig: buffSigData}, (putErr, hash, number) => {
-                  if(putErr){
-                    reject(putErr)
-                  } else {
-                    resolve({hash: hash.toString('hex'), number})
-                  }
-                })
-              }
+  // if initial option is true, then start seeding all user created torrents on start up
+  if (this._initial) {
+    const checkInternal = await fs.readdir(this._internal, { withFileTypes: false })
+    for (const checkInternalPath of checkInternal) {
+      const folderPath = path.join(this._internal, checkInternalPath)
+      if (checkAddress.test(checkInternalPath)) {
+        const checkTorrent = await Promise.any([
+          new Promise((resolve, reject) => {
+            setTimeout(() => { resolve(null) }, this._timeout)
+          }),
+          new Promise((resolve, reject) => {
+            this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
+              resolve(torrent)
             })
           })
-        })
-      }
-    
-      // keep the data we currently hold active by putting it back into the dht
-      keepData(data){
-        return new Promise((resolve, reject) => {
-          this.webtorrent.dht.put({k: Buffer.from(data.address, 'hex'), v: {ih: data.infoHash, ...data.stuff}, seq: data.sequence, sig: Buffer.from(data.sig, 'hex')}, (error, hash, number) => {
-            if(error){
-              reject(error)
-            } else {
-              resolve({hash: hash.toString('hex'), number})
-            }
-          })
-        })
-      }
-    
-      // tries to get the data from another user and put that recent data back into the dht to keep the data active
-      keepCurrent(address){
-        return new Promise((resolve, reject) => {
-          const buffAddKey = Buffer.from(address, 'hex')
-    
-          sha1(buffAddKey, (targetID) => {
-      
-            this.webtorrent.dht.get(targetID, (getErr, getData) => {
-              if (getErr) {
-                reject(getErr)
-              } else if(getData){
-                this.webtorrent.dht.put(getData, (putErr, hash, number) => {
-                  if(putErr){
-                    reject(putErr)
-                  } else {
-                    resolve({getData, putData: {hash: hash.toString('hex'), number}})
-                  }
-                })
-              } else if(!getData){
-                reject(new Error('could not find property'))
-              }
+        ])
+        if (checkTorrent) {
+          checkTorrent.folder = folderPath
+          const checkProperty = await Promise.any([
+            new Promise((resolve, reject) => { setTimeout(() => { resolve(null) }, this._timeout) }),
+            new Promise((resolve, reject) => {
+              this.ownData(checkInternalPath, checkTorrent.infoHash).then(res => {
+                resolve(res)
+              }).catch(error => {
+                console.log(error)
+                // most likely the infohash of this torrent does not match what we have currently, stop this torrent
+                this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
+                resolve(null)
+              })
             })
-          })
-        })
-      }
-    
-      // create a keypair
-      createKeypair () {
-        let {publicKey, secretKey} = ed.createKeyPair(ed.createSeed())
-    
-        return { address: publicKey.toString('hex'), secret: secretKey.toString('hex') }
-      }
-    
-      // extract the public key/address out of a link
-      addressFromLink(link){
-        if(!link || typeof(link) !== 'string'){
-          return ''
-        } else if(link.startsWith('bt')){
-          try {
-            const parsed = new URL(link)
-        
-            if(!parsed.hostname){
-              return ''
-            } else {
-              return parsed.hostname
+          ])
+          if (checkProperty) {
+            // don't overwrite the torrent's infohash even though they will both be the same
+            delete checkProperty.infoHash
+            for (const prop in checkProperty) {
+              checkTorrent[prop] = checkProperty[prop]
             }
-    
-          } catch (error) {
-            console.log(error)
-            return ''
+            checkTorrent.folder = folderPath
+            checkTorrent.side = true
+            console.log(checkInternalPath + ' is good')
           }
-        } else if(link.startsWith('magnet')){
-          try {
-            const parsed = new URL(link)
-    
-            const xs = parsed.searchParams.get('xs')
-      
-            const isMutableLink = xs && xs.startsWith(BTPK_PREFIX)
-        
-            if(!isMutableLink){
-              return ''
-            } else {
-              return xs.slice(BTPK_PREFIX.length)
+        }
+      } else if (checkTitle.test(checkInternalPath)) {
+        const checkTorrent = await Promise.any([
+          new Promise((resolve, reject) => {
+            setTimeout(() => { resolve(null) }, this._timeout)
+          }),
+          new Promise((resolve, reject) => {
+            this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
+              resolve(torrent)
+            })
+          })
+        ])
+        if (checkTorrent) {
+          checkTorrent.folder = folderPath
+          checkTorrent.title = checkInternalPath
+          checkTorrent.side = true
+          console.log(checkInternalPath + ' is good')
+        }
+      } else {
+        await fs.remove(folderPath)
+      }
+    }
+  }
+
+  // if share option is true, then start seeding(webtorrent.add seeds after torrent is downloaded) on start up
+  if (this._share) {
+    const checkExternal = await fs.readdir(this._external, { withFileTypes: false })
+    for (const checkExternalPath of checkExternal) {
+      const folderPath = path.join(this._external, checkExternalPath)
+      if (checkAddress.test(checkExternalPath)) {
+        const checkProperty = await Promise.any([
+          new Promise((resolve, reject) => { setTimeout(() => { resolve(null) }, this._timeout) }),
+          this.resolve(checkExternalPath)
+        ])
+        if (checkProperty) {
+          if (this._current) {
+            if (!await fs.pathExists(folderPath + path.sep + checkProperty.infoHash)) {
+              try {
+                await fs.emptyDir(folderPath)
+              } catch (error) {
+                console.log(error)
+              }
             }
-    
-          } catch (error) {
-            console.log(error)
-            return ''
+          } else if (!this._current) {
+            try {
+              await fs.ensureDir(folderPath)
+            } catch (error) {
+              console.log(error)
+            }
           }
+          const checkTorrent = await Promise.any([
+            new Promise((resolve, reject) => { setTimeout(() => { resolve(null) }, this._timeout) }),
+            new Promise((resolve, reject) => {
+              this.webtorrent.add(checkProperty.infoHash, { path: folderPath + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true }, torrent => {
+                resolve(torrent)
+              })
+            })
+          ])
+          if (checkTorrent) {
+            checkTorrent.folder = folderPath
+            checkTorrent.side = false
+            // don't overwrite the torrent's infohash even though they will both be the same
+            delete checkProperty.infoHash
+            for (const prop in checkProperty) {
+              checkTorrent[prop] = checkProperty[prop]
+            }
+            console.log(checkExternalPath + ' is good')
+          }
+        }
+      } else if (checkHash.test(checkExternalPath)) {
+        const checkTorrent = await Promise.any([
+          new Promise((resolve, reject) => { setTimeout(() => { resolve(null) }, this._timeout) }),
+          new Promise((resolve, reject) => {
+            this.webtorrent.add(checkExternalPath, { path: folderPath, destroyStoreOnDestroy: true }, torrent => {
+              resolve(torrent)
+            })
+          })
+        ])
+        if (checkTorrent) {
+          checkTorrent.folder = folderPath
+          checkTorrent.side = false
+          checkTorrent.title = crypto.createHash('md5').update(checkExternalPath).digest('hex')
+          console.log(checkExternalPath + ' is good')
+        }
+      } else {
+        await fs.remove(folderPath)
+      }
+    }
+  }
+}
+
+  // when we resume or seed a user created BEP46 torrent that has already been created before
+  // we have to check that the infohash of the torrent(remember we do not know the infohash before) matches the signature
+  // if it does not match, that means the data/torrent has been corrupted somehow
+  async ownData (address, infoHash) {
+    if (!await fs.pathExists(this._author + path.sep + address)) {
+      throw new Error('data was not found')
+    }
+    // get data from file
+    let data = await fs.readFile(this._author + path.sep + address)
+    // parse the data file
+    data = JSON.parse(data.toString())
+
+    const signatureBuff = Buffer.from(data.sig, 'hex')
+    const encodedSignatureData = encodeSigData({ seq: data.sequence, v: { ih: infoHash, ...data.stuff } })
+    const addressBuff = Buffer.from(data.address, 'hex')
+
+    if (infoHash !== data.infoHash || !ed.verify(signatureBuff, encodedSignatureData, addressBuff)) {
+      throw new Error('data does not match signature')
+    }
+    return data
+  }
+
+  // resolve public key address to an infohash
+  async resolveFunc (address) {
+    if (!address || typeof (address) !== 'string') {
+      throw new Error('address can not be parsed')
+    }
+    const addressKey = Buffer.from(address, 'hex')
+    const getData = await new Promise((resolve, reject) => {
+      sha1(addressKey, (targetID) => {
+        this.webtorrent.dht.get(targetID, (err, res) => {
+          if (err) {
+            reject(err)
+          } else if (res) {
+            resolve(res)
+          } else if (!res) {
+            reject(new Error('Could not resolve address'))
+          }
+        })
+      })
+    })
+    if (!checkHash.test(getData.v.ih.toString('utf-8')) || !Number.isInteger(getData.seq)) {
+      throw new Error('data is invalid')
+    }
+    for (const prop in getData.v) {
+      getData.v[prop] = getData.v[prop].toString('utf-8')
+    }
+    const { ih, ...stuff } = getData.v
+    return { magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: getData.seq, stuff, sig: getData.sig.toString('hex'), side: false, from: getData.id.toString('hex') }
+  }
+
+  // publish an infohash under a public key address in the dht
+  async publishFunc (address, secret, text) {
+    for (const prop in text) {
+      if (typeof (text[prop]) !== 'string') {
+        throw new Error('text data must be strings')
+      }
+    }
+    if (!checkHash.test(text.ih)) {
+      throw new Error('must have infohash')
+    }
+    if (!address || !secret) {
+      throw new Error('must have address and secret')
+    }
+
+    const buffAddKey = Buffer.from(address, 'hex')
+    const buffSecKey = secret ? Buffer.from(secret, 'hex') : null
+    const v = text
+
+    let main = null
+    let seq = null
+    if (await fs.pathExists(this._author + path.sep + address)) {
+      main = await fs.readFile(this._author + path.sep + address)
+      main = JSON.parse(data.toString())
+      seq = main.sequence + 1
+    } else {
+      seq = 0
+    }
+
+    const buffSig = ed.sign(encodeSigData({ seq, v }), buffAddKey, buffSecKey)
+
+    const putData = await new Promise((resolve, reject) => {
+      this.webtorrent.dht.put({ k: buffAddKey, v, seq, sig: buffSig }, (putErr, hash, number) => {
+        if (putErr) {
+          reject(putErr)
         } else {
-          return ''
+          resolve({ hash: hash.toString('hex'), number })
+        }
+      })
+    })
+    const { ih, ...stuff } = text
+    main = { magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: seq, stuff, sig: buffSig.toString('hex'), side: true, ...putData }
+    await fs.writeFile(this._author + path.sep + address, JSON.stringify(main))
+    return main
+  }
+
+  // async shred(address){
+  //     if(await fs.pathExists(this._author + path.sep + address)){
+  //       await fs.remove(this._author + path.sep + address)
+  //       return true
+  //     } else {
+  //       return false
+  //     }
+  //   }
+
+  // we use this function to seed a non-BEP46 torrent that we have already created before, not really needed but here just for consistency
+  async currentTitle (title) {
+    const haveTorrent = this.findTheTitle(title)
+    if (haveTorrent) {
+      return haveTorrent
+    }
+    const folderPath = path.join(this._internal, title)
+    if (!await fs.pathExists(folderPath)) {
+      throw new Error('folder does not exist')
+    }
+    checkTorrent = await Promise.race([
+      new Promise((resolve, reject) => {
+        setTimeout(() => { reject(new Error(title + ' took too long, it timed out')) }, this._timeout)
+      }),
+      new Promise((resolve, reject) => {
+        this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
+          resolve(torrent)
+        })
+      })
+    ])
+    checkTorrent.folder = folderPath
+    checkTorrent.title = title
+    checkTorrent.side = true
+    return checkTorrent
+  }
+
+  // we must use this function to seed a BEP46 torrent that we have already published before
+  async currentAddress (address) {
+    const haveTorrent = this.findTheAddress(address)
+    if (haveTorrent) {
+      return haveTorrent
+    }
+    const folderPath = path.join(this._internal, address)
+    if (!await fs.pathExists(folderPath)) {
+      throw new Error('folder does not exist')
+    }
+    const checkTorrent = await Promise.race([
+      new Promise((resolve, reject) => {
+        setTimeout(() => { reject(new Error(address + ' took too long, it timed out')) }, this._timeout)
+      }),
+      new Promise((resolve, reject) => {
+        this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
+          resolve(torrent)
+        })
+      })
+    ])
+    const checkProperty = await Promise.race([
+      new Promise((resolve, reject) => {
+        setTimeout(() => {
+          this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
+          reject(new Error(address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
+        }, this._timeout)
+      }),
+      new Promise((resolve, reject) => {
+        this.ownData(address, checkTorrent.infoHash).then(res => {
+          resolve(res)
+        }).catch(error => {
+          console.log(error)
+          // most likely the infohash of this torrent does not match what we have, stop this torrent and reject the promise
+          this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
+          reject(error)
+        })
+      })
+    ])
+    // don't overwrite the torrent's infohash even though they will both be the same
+    delete checkProperty.infoHash
+    checkProperty.folder = folderPath
+    checkProperty.side = true
+    for (const prop in checkProperty) {
+      checkTorrent[prop] = checkProperty[prop]
+    }
+    return checkTorrent
+  }
+
+  // download a regular non-BEP46 non-user created torrent by entering a 40 character infohash
+  async loadHash (hash) {
+    const haveTorrent = this.findTheHash(hash)
+    if (haveTorrent) {
+      return haveTorrent
+    }
+    // if user had torrent before, then empty the folder so previous data does not conflict with the infohash
+    const folderPath = path.join(this._external, hash)
+    // try {
+    //     await fs.emptyDir(folderPath)
+    // } catch (error) {
+    //     console.log(error)
+    // }
+    checkTorrent = await Promise.race([
+      new Promise((resolve, reject) => {
+        setTimeout(() => { reject(new Error(hash + ' took too long, it timed out')) }, this._timeout)
+      }),
+      new Promise((resolve, reject) => {
+        this.webtorrent.add(hash, { path: folderPath, destroyStoreOnDestroy: true }, torrent => {
+          resolve(torrent)
+        })
+      })
+    ])
+    checkTorrent.folder = folderPath
+    checkTorrent.side = false
+    return checkTorrent
+  }
+
+  // publish a regular non-BEP46 torrent, we need a path to the directory where the data is
+  // we copy it to a new sub-directory(inside the this._internal directory)
+  // that will have a 32 character md5 hash as it's sub-directory name
+  // we do this because we can not name it with the infohash
+  // because we do not know the infohash of this torrent beforehand
+  // we return the torrent along with the title
+  // that way the user knows the title when they want to start the torrent
+  async publishTitle (folder) {
+    if (!folder || typeof (folder) !== 'string') {
+      throw new Error('path ' + folder + ' does not work')
+    } else {
+      folder = { oldFolder: path.resolve(folder) }
+      folder.target = path.basename(folder.oldFolder)
+      folder.hashed = crypto.createHash('md5').update(folder.oldFolder).digest('hex')
+      folder.main = path.join(this._internal, folder.hashed)
+      folder.newFolder = folder.target.includes('.') ? folder.main + path.sep + folder.target : folder.main
+      const haveTorrent = this.findTheTitle(folder.hashed)
+      if (haveTorrent) {
+        return { torrent: haveTorrent, title: haveTorrent.title }
+      }
+      if (folder.target.includes('.')) {
+        try {
+          await fs.emptyDir(folder.main)
+        } catch (error) {
+          console.log(error)
         }
       }
+      await fs.copy(folder.oldFolder, folder.newFolder, { overwrite: true })
+    }
+    const checkTorrent = await Promise.race([
+      new Promise((resolve, reject) => {
+        setTimeout(() => { reject(new Error('torrent took too long, it timed out')) }, this._timeout)
+      }),
+      new Promise((resolve, reject) => {
+        this.webtorrent.seed(folder.main, { destroyStoreOnDestroy: true }, torrent => {
+          resolve(torrent)
+        })
+      })
+    ])
+    checkTorrent.folder = folder.main
+    checkTorrent.title = folder.hashed
+    checkTorrent.side = true
+    return { torrent: checkTorrent, title: checkTorrent.title }
+  }
+
+  // download a non-user created BEP46 torrent by their public key address, non-user meaning someone else's BEP46 torrent
+  async loadAddress (address) {
+    const haveTorrent = this.findTheAddress(address)
+    if (haveTorrent) {
+      return haveTorrent
+    }
+    const checkProperty = await Promise.race([
+      new Promise((resolve, reject) => {
+        setTimeout(() => { reject(new Error(address + ' property took too long, it timed out')) }, this._timeout)
+      }),
+      this.resolveFunc(address)
+    ])
+
+    checkProperty.folder = path.join(this._external, checkProperty.address)
+    checkProperty.side = false
+
+    // if current option is true, then if the infohash for the address is brand new then empty the directory and download the new infohash
+    // if the current option is false, then at least make sure the main folder which is named with the public key address exists
+    if (this._current) {
+      if (!await fs.pathExists(checkProperty.folder + path.sep + checkProperty.infoHash)) {
+        try {
+          await fs.emptyDir(checkProperty.folder)
+        } catch (error) {
+          console.log(error)
+        }
+      }
+    } else if (!this._current) {
+      if (!await fs.pathExists(checkProperty.folder)) {
+        try {
+          await fs.ensureDir(checkProperty.folder)
+        } catch (error) {
+          console.log(error)
+        }
+      }
+    }
+
+    const checkTorrent = await Promise.race([
+      new Promise((resolve, reject) => {
+        setTimeout(() => { reject(new Error(checkProperty.address + ' took too long, it timed out')) }, this._timeout)
+      }),
+      new Promise((resolve, reject) => {
+        this.webtorrent.add(checkProperty.infoHash, { path: checkProperty.folder + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true }, torrent => {
+          resolve(torrent)
+        })
+      })
+    ])
+    // don't overwrite the torrent's infohash even though they will both be the same
+    delete checkProperty.infoHash
+    for (const prop in checkProperty) {
+      checkTorrent[prop] = checkProperty[prop]
+    }
+    return checkTorrent
+  }
+
+  // publish a new BEP46 torrent, or update an address/public key with a new torrent
+  // we need a folder(string) passed in as an argument
+  // we check we have a torrent already for the public key address
+  // we then copy the data from the folder to the this._internal directory
+  // we return secret key along with the torrent because the user will need it
+  async publishAddress (folder, keypair) {
+    if (!keypair || !keypair.address || !keypair.secret) {
+      keypair = this.createKeypair()
+    } else {
+      const haveTorrent = this.findTheAddress(keypair.address)
+      if (haveTorrent) {
+        return { torrent: haveTorrent, secret: null }
+      }
+    }
+    if (!folder || typeof (folder) !== 'string') {
+      throw new Error('must have folder')
+    } else {
+      folder = { oldFolder: path.resolve(folder) }
+      folder.main = path.join(this._internal, keypair.address)
+      folder.target = path.basename(folder.oldFolder)
+      folder.newFolder = folder.target.includes('.') ? folder.main + path.sep + folder.target : folder.main
+      if (folder.target.includes('.')) {
+        try {
+          await fs.emptyDir(folder.main)
+        } catch (error) {
+          console.log(error)
+        }
+      }
+      await fs.copy(folder.oldFolder, folder.newFolder, { overwrite: true })
+    }
+    const checkTorrent = await Promise.race([
+      new Promise((resolve, reject) => {
+        setTimeout(() => { reject(new Error('torrent took too long, it timed out')) }, this._timeout)
+      }),
+      new Promise((resolve, reject) => {
+        this.webtorrent.seed(folder.main, { destroyStoreOnDestroy: true }, torrent => {
+          resolve(torrent)
+        })
+      })
+    ])
+    const checkProperty = await Promise.race([
+      new Promise((resolve, reject) => {
+        setTimeout(() => {
+          this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
+          reject(new Error(keypair.address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
+        }, this._timeout)
+      }),
+      new Promise((resolve, reject) => {
+        this.publishFunc(keypair.address, keypair.secret, { ih: checkTorrent.infoHash }).then(res => {
+          resolve(res)
+        }).catch(error => {
+          // if there is an error with publishing to the dht, then stop this torrent and reject the promise
+          this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
+          reject(error)
+        })
+      })
+    ])
+    // don't overwrite the torrent's infohash even though they will both be the same
+    delete checkProperty.infoHash
+    checkProperty.folder = folder.main
+    checkProperty.side = true
+    for (const prop in checkProperty) {
+      checkTorrent[prop] = checkProperty[prop]
+    }
+    return { torrent: checkTorrent, secret: keypair.secret }
+  }
+
+  // ------------- the below functions are for stopping or removing data and torrents
+
+  // stops all torrents
+  clearData () {
+    for (let i = 0; i < this.webtorrent.torrents.length; i++) {
+      this.webtorrent.remove(this.webtorrent.torrents[i].infoHash, { destroyStore: false })
+    }
+    return 'data was stopped'
+  }
+
+  // stops the torrent with the title(string), title is a 32 character md5 hash used for the directory name of a non-BEP46 user created torrent aka regular torrent
+  stopTitle (title) {
+    const checkTorrent = this.findTheTitle(title)
+    if (checkTorrent) {
+      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
+      return title + ' was stopped'
+    } else {
+      return title + ' was not found'
+    }
+  }
+
+  // stops the torrent with the 40 character infohash(string)
+  stopHash (hash) {
+    const checkTorrent = this.findTheHash(hash)
+    if (checkTorrent) {
+      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
+      return hash + ' was stopped'
+    } else {
+      return hash + ' was not found'
+    }
+  }
+
+  // stops the torrent with the 64 character public key(string)
+  stopAddress (address) {
+    const checkTorrent = this.findTheAddress(address)
+    if (checkTorrent) {
+      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
+      return address + ' was stopped'
+    } else {
+      return address + ' was not found'
+    }
+  }
+
+  // stop the torrent with the title, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
+  async removeTitle (title) {
+    const checkTorrent = this.findTheTitle(title)
+    if (checkTorrent) {
+      const folder = checkTorrent.folder
+      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
+      if (folder) {
+        try {
+          await fs.remove(folder)
+        } catch (error) {
+          console.log(error)
+        }
+      }
+    } else {
+      if (await fs.pathExists(path.join(this._external, title))) {
+        try {
+          await fs.remove(path.join(this._external, title))
+        } catch (error) {
+          console.log(error)
+        }
+      }
+      if (await fs.pathExists(path.join(this._internal, title))) {
+        try {
+          await fs.remove(path.join(this._internal, title))
+        } catch (error) {
+          console.log(error)
+        }
+      }
+    }
+    return title + ' has been removed'
+  }
+
+  // stop the torrent with the infohash, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
+  async removeHash (hash) {
+    const checkTorrent = this.findTheHash(hash)
+    if (checkTorrent) {
+      const folder = checkTorrent.folder
+      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
+      if (folder) {
+        try {
+          await fs.remove(folder)
+        } catch (error) {
+          console.log(error)
+        }
+      }
+    } else {
+      if (await fs.pathExists(path.join(this._external, hash))) {
+        try {
+          await fs.remove(path.join(this._external, hash))
+        } catch (error) {
+          console.log(error)
+        }
+      }
+      if (await fs.pathExists(path.join(this._internal, hash))) {
+        try {
+          await fs.remove(path.join(this._internal, hash))
+        } catch (error) {
+          console.log(error)
+        }
+      }
+    }
+    return hash + ' has been removed'
+  }
+
+  // stop the torrent with the address, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
+  async removeAddress (address) {
+    const checkedTorrent = this.findTheAddress(address)
+    if (checkedTorrent) {
+      const folder = checkedTorrent.folder
+      const side = checkedTorrent.side
+      this.webtorrent.remove(checkedTorrent.infoHash, { destroyStore: false })
+      if (folder) {
+        try {
+          await fs.remove(folder)
+        } catch (error) {
+          console.log(error)
+        }
+      }
+      if (side) {
+        try {
+          await fs.remove(this._author + path.sep + address)
+        } catch (error) {
+          console.log(error)
+        }
+      }
+    } else {
+      if (await fs.pathExists(path.join(this._external, address))) {
+        try {
+          await fs.remove(path.join(this._external, address))
+        } catch (error) {
+          console.log(error)
+        }
+      }
+      if (await fs.pathExists(path.join(this._internal, address))) {
+        try {
+          await fs.remove(path.join(this._internal, address))
+        } catch (error) {
+          console.log(error)
+        }
+      }
+      if (await fs.pathExists(this._author + path.sep + address)) {
+        await fs.remove(this._author + path.sep + address)
+      }
+    }
+    return address + ' was removed'
+  }
+
+  // --------------------- the below functions loops and gets the torrents we are seeking, if it is not found then null is returned
+  findTheFolder (folder) {
+    let tempTorrent = null
+    for (let i = 0; i < this.webtorrent.torrents.length; i++) {
+      if (this.webtorrent.torrents[i].folder === folder) {
+        tempTorrent = this.webtorrent.torrents[i]
+        break
+      }
+    }
+    return tempTorrent
+  }
+
+  findTheTitle (title) {
+    let tempTorrent = null
+    for (let i = 0; i < this.webtorrent.torrents.length; i++) {
+      if (this.webtorrent.torrents[i].title === title) {
+        tempTorrent = this.webtorrent.torrents[i]
+        break
+      }
+    }
+    return tempTorrent
+  }
+
+  findTheHash (hash) {
+    let tempTorrent = null
+    for (let i = 0; i < this.webtorrent.torrents.length; i++) {
+      if (this.webtorrent.torrents[i].infoHash === hash) {
+        tempTorrent = this.webtorrent.torrents[i]
+        break
+      }
+    }
+    return tempTorrent
+  }
+
+  findTheAddress (address) {
+    let tempTorrent = null
+    for (let i = 0; i < this.webtorrent.torrents.length; i++) {
+      if (this.webtorrent.torrents[i].address === address) {
+        tempTorrent = this.webtorrent.torrents[i]
+        break
+      }
+    }
+    return tempTorrent
+  }
+
+  // -------------- the below functions are BEP46 helpders, especially bothGetPut which keeps the data active in the dht ----------------
+
+  // this function is used to keep data active in the dht
+  // torrent data is passed in as an argument
+  // it gets the most recent data from another user in the dht
+  // then puts that most recent data back into the dht
+  // if it  can not get the most recent data from another user
+  // then we put the torrent data that we currently have back into the dht
+  bothGetPut (data) {
+    return new Promise((resolve, reject) => {
+      const buffAddKey = Buffer.from(data.address, 'hex')
+      const buffSigData = Buffer.from(data.sig, 'hex')
+      sha1(buffAddKey, (targetID) => {
+        this.webtorrent.dht.get(targetID, (getErr, getData) => {
+          if (getErr) {
+            console.log(getErr)
+          }
+          if (getData) {
+            this.webtorrent.dht.put(getData, (putErr, hash, number) => {
+              if (putErr) {
+                reject(putErr)
+              } else {
+                resolve({ getData, putData: { hash: hash.toString('hex'), number } })
+              }
+            })
+          } else if (!getData) {
+            this.webtorrent.dht.put({ k: buffAddKey, v: { ih: data.infoHash, ...data.stuff }, seq: data.sequence, sig: buffSigData }, (putErr, hash, number) => {
+              if (putErr) {
+                reject(putErr)
+              } else {
+                resolve({ hash: hash.toString('hex'), number })
+              }
+            })
+          }
+        })
+      })
+    })
+  }
+
+  // keep the data we currently hold active by putting it back into the dht
+  keepData (data) {
+    return new Promise((resolve, reject) => {
+      this.webtorrent.dht.put({ k: Buffer.from(data.address, 'hex'), v: { ih: data.infoHash, ...data.stuff }, seq: data.sequence, sig: Buffer.from(data.sig, 'hex') }, (error, hash, number) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve({ hash: hash.toString('hex'), number })
+        }
+      })
+    })
+  }
+
+  // tries to get the data from another user and put that recent data back into the dht to keep the data active
+  keepCurrent (address) {
+    return new Promise((resolve, reject) => {
+      const buffAddKey = Buffer.from(address, 'hex')
+
+      sha1(buffAddKey, (targetID) => {
+        this.webtorrent.dht.get(targetID, (getErr, getData) => {
+          if (getErr) {
+            reject(getErr)
+          } else if (getData) {
+            this.webtorrent.dht.put(getData, (putErr, hash, number) => {
+              if (putErr) {
+                reject(putErr)
+              } else {
+                resolve({ getData, putData: { hash: hash.toString('hex'), number } })
+              }
+            })
+          } else if (!getData) {
+            reject(new Error('could not find property'))
+          }
+        })
+      })
+    })
+  }
+
+  // create a keypair
+  createKeypair () {
+    const { publicKey, secretKey } = ed.createKeyPair(ed.createSeed())
+
+    return { address: publicKey.toString('hex'), secret: secretKey.toString('hex') }
+  }
+
+  // extract the public key/address out of a link
+  addressFromLink (link) {
+    if (!link || typeof (link) !== 'string') {
+      return ''
+    } else if (link.startsWith('bt')) {
+      try {
+        const parsed = new URL(link)
+
+        if (!parsed.hostname) {
+          return ''
+        } else {
+          return parsed.hostname
+        }
+      } catch (error) {
+        console.log(error)
+        return ''
+      }
+    } else if (link.startsWith('magnet')) {
+      try {
+        const parsed = new URL(link)
+
+        const xs = parsed.searchParams.get('xs')
+
+        const isMutableLink = xs && xs.startsWith(BTPK_PREFIX)
+
+        if (!isMutableLink) {
+          return ''
+        } else {
+          return xs.slice(BTPK_PREFIX.length)
+        }
+      } catch (error) {
+        console.log(error)
+        return ''
+      }
+    } else {
+      return ''
+    }
+  }
 }
 
 module.exports = Main

--- a/main.js
+++ b/main.js
@@ -355,10 +355,10 @@ delayTimeOut(timeout, data, res){
 
   // we use this function to seed a non-BEP46 torrent that we have already created before, not really needed but here just for consistency
   async currentHash (hash) {
-    // const haveTorrent = this.findTheHash(hash)
-    // if (haveTorrent) {
-    //   return haveTorrent
-    // }
+    const haveTorrent = this.findTheHash(hash)
+    if (haveTorrent) {
+      return haveTorrent
+    }
     const folderPath = path.join(this._internal, hash)
     if (!await fs.pathExists(folderPath)) {
       throw new Error('folder does not exist')
@@ -379,10 +379,10 @@ delayTimeOut(timeout, data, res){
 
   // we must use this function to seed a BEP46 torrent that we have already published before
   async currentAddress (address) {
-    // const haveTorrent = this.findTheAddress(address)
-    // if (haveTorrent) {
-    //   return haveTorrent
-    // }
+    const haveTorrent = this.findTheAddress(address)
+    if (haveTorrent) {
+      return haveTorrent
+    }
     const folderPath = path.join(this._internal, address)
     if (!await fs.pathExists(folderPath)) {
       throw new Error('folder does not exist')
@@ -425,10 +425,10 @@ delayTimeOut(timeout, data, res){
 
   // download a regular non-BEP46 non-user created torrent by entering a 40 character infohash
   async loadHash (hash) {
-    // const haveTorrent = this.findTheHash(hash)
-    // if (haveTorrent) {
-    //   return haveTorrent
-    // }
+    const haveTorrent = this.findTheHash(hash)
+    if (haveTorrent) {
+      return haveTorrent
+    }
     // if user had torrent before, then empty the folder so previous data does not conflict with the infohash
     const folderPath = path.join(this._external, hash)
     const checkTorrent = await Promise.race([
@@ -482,10 +482,10 @@ delayTimeOut(timeout, data, res){
 
   // download a non-user created BEP46 torrent by their public key address, non-user meaning someone else's BEP46 torrent
   async loadAddress (address) {
-    // const haveTorrent = this.findTheAddress(address)
-    // if (haveTorrent) {
-    //   return haveTorrent
-    // }
+    const haveTorrent = this.findTheAddress(address)
+    if (haveTorrent) {
+      return haveTorrent
+    }
     const checkProperty = await Promise.race([
       this.delayTimeOut(this._timeout, new Error(address + ' property took too long, it timed out'), false),
       this.resolveFunc(address)

--- a/main.js
+++ b/main.js
@@ -736,8 +736,8 @@ delayTimeOut(timeout, data, res){
       }
       function handleFiles(name, file, info){
         // fs.writeFile(path.join(folderPath, info.filename), Readable.from(file))
-        const saveTo = fs.createWriteStream(path.join(folderPath, info.filename))
-        file.pipe(saveTo)
+        // const saveTo = fs.createWriteStream(path.join(folderPath, info.filename))
+        file.pipe(fs.createWriteStream(path.join(folderPath, info.filename)))
       }
       function handleErrors(error){
         handleRemoval()

--- a/main.js
+++ b/main.js
@@ -1,0 +1,849 @@
+const WebTorrent = require('webtorrent')
+const fs = require('fs-extra')
+const path = require('path')
+const crypto = require('crypto')
+const sha1 = require('simple-sha1')
+const ed = require('ed25519-supercop')
+const bencode = require('bencode')
+// const EventEmitter = require('events').EventEmitter
+
+const BTPK_PREFIX = 'urn:btpk:'
+function encodeSigData (msg) {
+  const ref = { seq: msg.seq, v: msg.v }
+  if (msg.salt) ref.salt = msg.salt
+  return bencode.encode(ref).slice(1, -1)
+}
+const checkHash = new RegExp('^[a-fA-F0-9]{40}$')
+const checkAddress = new RegExp('^[a-fA-F0-9]{64}$')
+const checkTitle = new RegExp('^[a-f0-9]{32}$')
+const defOpts = {folder: __dirname, storage: 'storage', author: 'author', external: 'external', internal: 'internal', timeout: 60000, share: false, current: true, initial: true}
+
+async function keepUpdated(self){
+    self._readyToGo = false
+    for(let i = 0;i < self.webtorrent.torrents.length;i++){
+        if(self.webtorrent.torrents[i].address){
+            try {
+                await self.bothGetPut(self.webtorrent.torrents[i])
+            } catch (error) {
+                console.log(error)
+            }
+            await new Promise((resolve, reject) => setTimeout(resolve, 5000))
+        }
+    }
+    self._readyToGo = true
+}
+
+async function startUp(self){
+    // if(self._status.clear){
+    //     try {
+    //         await fs.emptyDir(self._external)
+    //         await fs.emptyDir(self._internal)
+    //         await fs.emptyDir(self._author)
+    //     } catch (error) {
+    //         console.log(error)
+    //     }
+    // }
+    if(self._status.initial){
+        let checkInternal = await fs.readdir(self._internal, {withFileTypes: false})
+        for(let i = 0;i < checkInternal.length;i++){
+            let folderPath = self._internal + path.sep + checkInternal[i]
+            if(checkAddress.test(checkInternal[i])){
+                // if(self.findTheAddress(checkInternal[i])){
+                //     continue
+                // }
+                let checkTorrent = await Promise.any([
+                    new Promise((resolve, reject) => {
+                        setTimeout(() => {resolve(null)}, self._status.timeout)
+                    }),
+                    new Promise((resolve, reject) => {
+                        self.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
+                            resolve(torrent)
+                        })
+                    })
+                ])
+                if(checkTorrent){
+                    checkTorrent.folder = folderPath
+                    let checkProperty = await Promise.any([
+                        new Promise((resolve, reject) => {setTimeout(() => {resolve(null)}, self._status.timeout)}),
+                        new Promise((resolve, reject) => {
+                            self.ownData(checkInternal[i], checkTorrent.infoHash).then(res => {
+                                resolve(res)
+                            }).catch(error => {
+                                console.log(error)
+                                self.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+                                resolve(null)
+                            })
+                        })
+                    ])
+                    if(checkProperty){
+                        delete checkProperty.infoHash
+                        for(const prop in checkProperty){
+                            checkTorrent[prop] = checkProperty[prop]
+                        }
+                        checkTorrent.folder = folderPath
+                        checkTorrent.side = true
+                        console.log(checkInternal[i] + ' is good')
+                    }
+                }
+            } else if(checkTitle.test(checkInternal[i])){
+                // if(self.findTheTitle(checkInternal[i])){
+                //     continue
+                // }
+                let checkTorrent = await Promise.any([
+                    new Promise((resolve, reject) => {
+                        setTimeout(() => {resolve(null)}, self._status.timeout)
+                    }),
+                    new Promise((resolve, reject) => {
+                        self.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
+                            resolve(torrent)
+                        })
+                    })
+                ])
+                if(checkTorrent){
+                    checkTorrent.folder = folderPath
+                    checkTorrent.title = checkInternal[i]
+                    checkTorrent.side = true
+                    console.log(checkInternal[i] + ' is good')
+                }
+            } else {
+                await fs.remove(folderPath)
+            }
+        }
+    }
+    if(self._status.share){
+        let checkExternal = await fs.readdir(self._external, {withFileTypes: false})
+        for(let i = 0;i < checkExternal.length;i++){
+            let folderPath = self._external + path.sep + checkExternal[i]
+            if(checkAddress.test(checkExternal[i])){
+                // if(self.findTheAddress(checkExternal[i])){
+                //     continue
+                // }
+                let checkProperty = await Promise.any([
+                    new Promise((resolve, reject) => {setTimeout(() => {resolve(null)}, self._status.timeout)}),
+                    self.resolve(checkExternal[i])
+                ])
+                if(checkProperty){
+                    if(self._status.current){
+                        if(!await fs.pathExists(folderPath + path.sep + checkProperty.infoHash)){
+                            try {
+                                await fs.emptyDir(folderPath)
+                            } catch (error) {
+                                console.log(error)
+                            }
+                        }
+                    } else if(!self._status.current){
+                        try {
+                            await fs.ensureDir(folderPath)
+                        } catch (error) {
+                            console.log(error)
+                        }
+                    }
+                    let checkTorrent = await Promise.any([
+                        new Promise((resolve, reject) => {setTimeout(() => {resolve(null)}, self._status.timeout)}),
+                        new Promise((resolve, reject) => {
+                            self.webtorrent.add(checkProperty.infoHash, {path: folderPath + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true}, torrent => {
+                                resolve(torrent)
+                            })
+                        })
+                    ])
+                    if(checkTorrent){
+                        checkTorrent.folder = folderPath
+                        checkTorrent.side = false
+                        delete checkProperty.infoHash
+                        for(const prop in checkProperty){
+                            checkTorrent[prop] = checkProperty[prop]
+                        }
+                        console.log(checkExternal[i] + ' is good')
+                    }
+                }
+            } else if(checkHash.test(checkExternal[i])){
+                // if(self.findTheHash(checkExternal[i])){
+                //     continue
+                // }
+                let checkTorrent = await Promise.any([
+                    new Promise((resolve, reject) => {setTimeout(() => {resolve(null)}, self._status.timeout)}),
+                    new Promise((resolve, reject) => {
+                        self.webtorrent.add(checkExternal[i], {path: folderPath, destroyStoreOnDestroy: true}, torrent => {
+                            resolve(torrent)
+                        })
+                    })
+                ])
+                if(checkTorrent){
+                    checkTorrent.folder = folderPath
+                    checkTorrent.side = false
+                    checkTorrent.title = crypto.createHash('md5').update(checkExternal[i]).digest("hex")
+                    console.log(checkExternal[i] + ' is good')
+                }
+            } else {
+                await fs.remove(folderPath)
+            }
+        }
+    }
+}
+
+class Main {
+    constructor(opts = {}){
+        const finalOpts = {...defOpts, ...opts}
+        finalOpts.folder = path.resolve(finalOpts.folder)
+        fs.ensureDirSync(finalOpts.folder)
+
+        this._status = {current: finalOpts.current, share: finalOpts.share, timeout: finalOpts.timeout, initial: finalOpts.initial}
+        this._storage = finalOpts.folder + path.sep + finalOpts.storage
+        this._external = this._storage + path.sep + finalOpts.external
+        this._internal = this._storage + path.sep + finalOpts.internal
+        this._author = finalOpts.folder + path.sep + finalOpts.author
+        if(!fs.pathExistsSync(this._storage)){
+            fs.ensureDirSync(this._storage)
+        }
+        if(!fs.pathExistsSync(this._external)){
+            fs.ensureDirSync(this._external)
+        }
+        if(!fs.pathExistsSync(this._internal)){
+            fs.ensureDirSync(this._internal)
+        }
+        if(!fs.pathExistsSync(this._author)){
+            fs.ensureDirSync(this._author)
+        }
+        this.webtorrent = new WebTorrent({dht: {verify: ed.verify}})
+        this.webtorrent.on('error', error => {
+            console.log(error)
+        })
+        this._readyToGo = true
+        startUp(this).catch(error => {console.log(error)})
+        setInterval(() => {
+            if(this._readyToGo){
+                keepUpdated(this).catch(error => {console.log(error)})
+            }
+        }, 3600000)
+    }
+
+    async ownData(address, infoHash){
+        if(!await fs.pathExists(this._author + path.sep + address)){
+            throw new Error('data was not found')
+        }
+        let data = await fs.readFile(this._author + path.sep + address)
+        data = JSON.parse(data.toString())
+        if(infoHash !== data.infoHash || !ed.verify(Buffer.from(data.sig, 'hex'), encodeSigData({seq: data.sequence, v: {ih: infoHash, ...data.stuff}}), Buffer.from(data.address, 'hex'))){
+          throw new Error('data does not match signature')
+        }
+        return data
+      }
+
+    async resolve(address){
+        if(!address || typeof(address) !== 'string'){
+            throw new Error('address can not be parsed')
+        }
+        const addressKey = Buffer.from(address, 'hex')
+        return await new Promise((resolve, reject) => {
+            sha1(addressKey, (targetID) => {
+                this.webtorrent.dht.get(targetID, (err, res) => {
+                    if(err){
+                    reject(err)
+                    } else if(res){
+                    if(!checkHash.test(res.v.ih.toString('utf-8')) || !Number.isInteger(res.seq)){
+                        reject(new Error('data is invalid'))
+                    }
+                    for(const prop in res.v){
+                        res.v[prop] = res.v[prop].toString('utf-8')
+                    }
+                    let {ih, ...stuff} = res.v
+                    resolve({magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: res.seq, stuff, sig: res.sig.toString('hex'), side: false, netdata: res})
+                    } else if(!res){
+                    reject(new Error('Could not resolve address'))
+                    }
+                })
+            })
+        })
+      }
+
+      async publish(address, secret, text){
+            for(let prop in text){
+              if(typeof(text[prop]) !== 'string'){
+                this.webtorrent.remove(text.ih, {destroyStore: false})
+                throw new Error('text data must be strings')
+              }
+            }
+            if(!checkHash.test(text.ih)){
+                this.webtorrent.remove(text.ih, {destroyStore: false})
+              throw new Error('must have infohash')
+            }
+            if(!address || !secret){
+                this.webtorrent.remove(text.ih, {destroyStore: false})
+              throw new Error('must have address and secret')
+            }
+        
+            const buffAddKey = Buffer.from(address, 'hex')
+            const buffSecKey = secret ? Buffer.from(secret, 'hex') : null
+            const v = text
+            const buffSig = ed.sign(encodeSigData({seq, v}), buffAddKey, buffSecKey)
+      
+            let data = null
+            let seq = null
+            if(await fs.pathExists(this._author + path.sep + address)){
+              data = await fs.readFile(this._author + path.sep + address)
+              data = JSON.parse(data.toString())
+              seq = data.sequence + 1
+            } else {
+              seq = 0
+            }
+            let putData = await new Promise((resolve, reject) => {
+                this.webtorrent.dht.put({k: buffAddKey, v, seq, sig: buffSig}, (putErr, hash, number) => {
+                    if(putErr){
+                        this.webtorrent.remove(text.ih, {destroyStore: false})
+                        reject(putErr)
+                    } else {
+                        resolve({hash: hash.toString('hex'), number})
+                    }
+                })
+            })
+            let {ih, ...stuff} = text
+            let main = {magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: seq, stuff, sig: buffSig.toString('hex'), side: true, ...putData}
+            await fs.writeFile(this._author + path.sep + address, JSON.stringify(main))
+            return main
+      }
+
+      bothGetPut(data){
+        return new Promise((resolve, reject) => {
+          const buffAddKey = Buffer.from(data.address, 'hex')
+          const buffSigData = Buffer.from(data.sig, 'hex')
+          sha1(buffAddKey, (targetID) => {
+      
+            this.webtorrent.dht.get(targetID, (getErr, getData) => {
+              if(getErr){
+                console.log(getErr)
+              }
+              if(getData){
+                this.webtorrent.dht.put(getData, (putErr, hash, number) => {
+                  if(putErr){
+                    reject(putErr)
+                  } else {
+                    resolve({getData, putData: {hash: hash.toString('hex'), number}})
+                  }
+                })
+              } else if(!getData){
+                this.webtorrent.dht.put({k: buffAddKey, v: {ih: data.infoHash, ...data.stuff}, seq: data.sequence, sig: buffSigData}, (putErr, hash, number) => {
+                  if(putErr){
+                    reject(putErr)
+                  } else {
+                    resolve({hash: hash.toString('hex'), number})
+                  }
+                })
+              }
+            })
+          })
+        })
+      }
+    
+      saveData(data){
+        return new Promise((resolve, reject) => {
+          this.webtorrent.dht.put({k: Buffer.from(data.address, 'hex'), v: {ih: data.infoHash, ...data.stuff}, seq: data.sequence, sig: Buffer.from(data.sig, 'hex')}, (error, hash, number) => {
+            if(error){
+              reject(error)
+            } else {
+              resolve({hash: hash.toString('hex'), number})
+            }
+          })
+        })
+      }
+    
+      keepCurrent(address){
+        return new Promise((resolve, reject) => {
+          const buffAddKey = Buffer.from(address, 'hex')
+    
+          sha1(buffAddKey, (targetID) => {
+      
+            this.webtorrent.dht.get(targetID, (getErr, getData) => {
+              if (getErr) {
+                reject(getErr)
+              } else if(getData){
+                this.webtorrent.dht.put(getData, (putErr, hash, number) => {
+                  if(putErr){
+                    reject(putErr)
+                  } else {
+                    resolve({getData, putData: {hash: hash.toString('hex'), number}})
+                  }
+                })
+              } else if(!getData){
+                reject(new Error('could not find property'))
+              }
+            })
+          })
+        })
+      }
+    
+      createKeypair () {
+        let {publicKey, secretKey} = ed.createKeyPair(ed.createSeed())
+    
+        return { address: publicKey.toString('hex'), secret: secretKey.toString('hex') }
+      }
+    
+      addressFromLink(link){
+        if(!link || typeof(link) !== 'string'){
+          return ''
+        } else if(link.startsWith('bt')){
+          try {
+            const parsed = new URL(link)
+        
+            if(!parsed.hostname){
+              return ''
+            } else {
+              return parsed.hostname
+            }
+    
+          } catch (error) {
+            console.log(error)
+            return ''
+          }
+        } else if(link.startsWith('magnet')){
+          try {
+            const parsed = new URL(link)
+    
+            const xs = parsed.searchParams.get('xs')
+      
+            const isMutableLink = xs && xs.startsWith(BTPK_PREFIX)
+        
+            if(!isMutableLink){
+              return ''
+            } else {
+              return xs.slice(BTPK_PREFIX.length)
+            }
+    
+          } catch (error) {
+            console.log(error)
+            return ''
+          }
+        } else {
+          return ''
+        }
+      }
+
+    async shred(address){
+        if(await fs.pathExists(this._author + path.sep + address)){
+          await fs.remove(this._author + path.sep + address)
+          return true
+        } else {
+          return false
+        }
+      }
+
+    async ownTitle(title){
+        let haveTorrent = this.findTheTitle(title)
+        if(haveTorrent){
+            return haveTorrent
+        }
+        let folderPath = this._internal + path.sep + title
+        if(!await fs.pathExists(folderPath)){
+            throw new Error('folder does not exist')
+        }
+        checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error(title + ' took too long, it timed out'))}, this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        checkTorrent.folder = folderPath
+        checkTorrent.title = title
+        checkTorrent.side = true
+        return checkTorrent
+    }
+
+    async ownAddress(address){
+        let haveTorrent = this.findTheAddress(address)
+        if(haveTorrent){
+            return haveTorrent
+        }
+        let folderPath = this._internal + path.sep + address
+        if(!await fs.pathExists(folderPath)){
+            throw new Error('folder does not exist')
+        }
+        let checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error(address + ' took too long, it timed out'))}, this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        let checkProperty = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+                    reject(new Error(address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
+                },this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.ownData(address, checkTorrent.infoHash).then(res => {
+                    resolve(res)
+                }).catch(error => {
+                    console.log(error)
+                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+                    reject(error)
+                })
+            })
+        ])
+        delete checkProperty.infoHash
+        checkProperty.folder = folderPath
+        checkProperty.side = true
+        for(const prop in checkProperty){
+            checkTorrent[prop] = checkProperty[prop]
+        }
+        return checkTorrent
+    }
+
+    async loadHash(hash){
+        let haveTorrent = this.findTheHash(hash)
+        if(haveTorrent){
+            return haveTorrent
+        }
+        // if user had torrent before, then empty the folder so previous data does notconflict with the infohash
+        let folderPath = this._external + path.sep + hash
+        // try {
+        //     await fs.emptyDir(folderPath)
+        // } catch (error) {
+        //     console.log(error)
+        // }
+        checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error(hash + ' took too long, it timed out'))}, this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.add(hash, {path: folderPath, destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        checkTorrent.folder = folderPath
+        checkTorrent.side = false
+        checkTorrent.title = crypto.createHash('md5').update(hash).digest("hex")
+        return checkTorrent
+    }
+
+    async publishTitle(folder){
+        if(!folder || typeof(folder) !== 'string'){
+            throw new Error('path ' + folder + ' does not work')
+        } else {
+            folder = {oldFolder: path.resolve(folder)}
+            folder.target = path.basename(folder.oldFolder)
+            folder.hashed = crypto.createHash('md5').update(folder.oldFolder).digest("hex")
+            folder.main = this._internal + path.sep + folder.hashed
+            folder.newFolder = folder.target.includes('.') ? folder.main + path.sep + folder.target : folder.main
+            let haveTorrent = this.findTheTitle(folder.hashed)
+            if(haveTorrent){
+                return {torrent: haveTorrent, title: haveTorrent.title}
+            }
+            if(folder.target.includes('.')){
+                try {
+                    await fs.emptyDir(folder.main)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            await fs.copy(folder.oldFolder, folder.newFolder, {overwrite: true})
+        }
+        let checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error('torrent took too long, it timed out'))}, this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.seed(folder.main, {destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        checkTorrent.folder = folder.main
+        checkTorrent.title = folder.hashed
+        checkTorrent.side = true
+        return {torrent: checkTorrent, title: checkTorrent.title}
+    }
+
+    async loadAddress(address){
+        let haveTorrent = this.findTheAddress(address)
+        if(haveTorrent){
+            return haveTorrent
+        }
+        let checkProperty = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error(address + ' property took too long, it timed out'))}, this._status.timeout)
+            }),
+            this.resolve(address)
+        ])
+
+        checkProperty.folder = this._external + path.sep + checkProperty.address
+        checkProperty.side = false
+
+        // if user had this torrent before and data or files were added in this folder, then the site might be messed up, we empty the folder that way the infohash is intact
+        if(this._status.current){
+            if(!await fs.pathExists(checkProperty.folder + path.sep + checkProperty.infoHash)){
+                try {
+                    await fs.emptyDir(checkProperty.folder)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        } else if(!this._status.current){
+            if(!await fs.pathExists(checkProperty.folder)){
+                try {
+                    await fs.ensureDir(checkProperty.folder)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        }
+
+        let checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error(checkProperty.address + ' took too long, it timed out'))}, this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.add(checkProperty.infoHash, {path: checkProperty.folder + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        delete checkProperty.infoHash
+        for(const prop in checkProperty){
+            checkTorrent[prop] = checkProperty[prop]
+        }
+        return checkTorrent
+    }
+    async publishAddress(folder, keypair){
+        if(!keypair || !keypair.address || !keypair.secret){
+            keypair = this.createKeypair()
+        }
+        let haveTorrent = this.findTheAddress(keypair.address)
+        if(haveTorrent){
+            return {torrent: haveTorrent, secret: null}
+        }
+        if(!folder || typeof(folder) !== 'string'){
+            throw new Error('must have folder')
+        } else {
+            folder = {oldFolder: path.resolve(folder)}
+            folder.main = this._internal + path.sep + keypair.address
+            folder.target = path.basename(folder.oldFolder)
+            folder.newFolder = folder.target.includes('.') ? folder.main + path.sep + folder.target : folder.main
+            if(folder.target.includes('.')){
+                try {
+                    await fs.emptyDir(folder.main)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            await fs.copy(folder.oldFolder, folder.newFolder, {overwrite: true})
+        }
+        let checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error('torrent took too long, it timed out'))},this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.seed(folder.main, {destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        let checkProperty = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+                    reject(new Error(keypair.address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
+                },this._status.timeout)
+            }),
+            this.publish(keypair.address, keypair.secret, {ih: checkTorrent.infoHash})
+        ])
+        const tempSecret = checkProperty.secret
+        delete checkProperty.infoHash
+        delete checkProperty.secret
+        checkProperty.folder = folder.main
+        checkProperty.side = true
+        for(const prop in checkProperty){
+            checkTorrent[prop] = checkProperty[prop]
+        }
+        return {torrent: checkTorrent, secret: tempSecret}
+    }
+    
+    clearData(){
+        for(let i = 0;i < this.webtorrent.torrents.length;i++){
+            this.webtorrent.remove(this.webtorrent.torrents[i].infoHash, {destroyStore: false})
+        }
+        return 'data was stopped'
+    }
+
+    stopTitle(title){
+        let checkTorrent = this.findTheTitle(title)
+        if(checkTorrent){
+            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+            return title + ' was stopped'
+        } else {
+            return title + ' was not found'
+        }
+    }
+    
+    async removeTitle(title){
+        let checkTorrent = this.findTheTitle(title)
+        if(checkTorrent){
+            let folder = checkTorrent.folder
+            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+            if(folder){
+                try {
+                    await fs.remove(folder)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        } else {
+            if(await fs.pathExists(this._external + path.sep + title)){
+                try {
+                    await fs.remove(this._external + path.sep + title)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            if(await fs.pathExists(this._internal + path.sep + title)){
+                try {
+                    await fs.remove(this._internal + path.sep + title)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        }
+        return title + ' has been removed'
+    }
+
+    stopHash(hash){
+        let checkTorrent = this.findTheHash(hash)
+        if(checkTorrent){
+            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+            return hash + ' was stopped'
+        } else {
+            return hash + ' was not found'
+        }
+    }
+    
+    async removeHash(hash){
+        let checkTorrent = this.findTheHash(hash)
+        if(checkTorrent){
+            let folder = checkTorrent.folder
+            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+            if(folder){
+                try {
+                    await fs.remove(folder)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        } else {
+            if(await fs.pathExists(this._external + path.sep + hash)){
+                try {
+                    await fs.remove(this._external + path.sep + hash)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            if(await fs.pathExists(this._internal + path.sep + hash)){
+                try {
+                    await fs.remove(this._internal + path.sep + hash)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        }
+        return hash + ' has been removed'
+    }
+    stopAddress(address){
+        let checkTorrent = this.findTheAddress(address)
+        if(checkTorrent){
+            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+            return address + ' was stopped'   
+        } else {
+            return address + ' was not found'
+        }
+    }
+    async removeAddress(address){
+        let checkedTorrent = this.findTheAddress(address)
+        if(checkedTorrent){
+            let folder = checkedTorrent.folder
+            let side = checkedTorrent.side
+            this.webtorrent.remove(checkedTorrent.infoHash, {destroyStore: false})
+            if(folder){
+                try {
+                    await fs.remove(folder)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            if(side){
+                try {
+                    await fs.remove(this._author + path.sep + address)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        } else {
+            if(await fs.pathExists(this._external + path.sep + address)){
+                try {
+                    await fs.remove(this._external + path.sep + address)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            if(await fs.pathExists(this._internal + path.sep + address)){
+                try {
+                    await fs.remove(this._internal + path.sep + address)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            if(await fs.pathExists(this._author + path.sep + address)){
+                await fs.remove(this._author + path.sep + address)
+              }
+        }
+        return address + ' was removed'
+    }
+    findTheFolder(folder){
+        let tempTorrent = null
+        for(let i = 0;i < this.webtorrent.torrents.length;i++){
+            if(this.webtorrent.torrents[i].folder === folder){
+                tempTorrent = this.webtorrent.torrents[i]
+                break
+            }
+        }
+        return tempTorrent
+    }
+    findTheTitle(title){
+        let tempTorrent = null
+        for(let i = 0;i < this.webtorrent.torrents.length;i++){
+            if(this.webtorrent.torrents[i].title === title){
+                tempTorrent = this.webtorrent.torrents[i]
+                break
+            }
+        }
+        return tempTorrent
+    }
+    findTheHash(hash){
+        let tempTorrent = null
+        for(let i = 0;i < this.webtorrent.torrents.length;i++){
+            if(this.webtorrent.torrents[i].infoHash === hash){
+                tempTorrent = this.webtorrent.torrents[i]
+                break
+            }
+        }
+        return tempTorrent
+    }
+    findTheAddress(address){
+        let tempTorrent = null
+        for(let i = 0;i < this.webtorrent.torrents.length;i++){
+            if(this.webtorrent.torrents[i].address === address){
+                tempTorrent = this.webtorrent.torrents[i]
+                break
+            }
+        }
+        return tempTorrent
+    }
+}
+
+module.exports = Main

--- a/main.js
+++ b/main.js
@@ -286,7 +286,6 @@ class Main {
             const buffAddKey = Buffer.from(address, 'hex')
             const buffSecKey = secret ? Buffer.from(secret, 'hex') : null
             const v = text
-            const buffSig = ed.sign(encodeSigData({seq, v}), buffAddKey, buffSecKey)
       
             let data = null
             let seq = null
@@ -297,6 +296,10 @@ class Main {
             } else {
               seq = 0
             }
+
+            const buffSig = ed.sign(encodeSigData({seq, v}), buffAddKey, buffSecKey)
+
+            
             let putData = await new Promise((resolve, reject) => {
                 this.webtorrent.dht.put({k: buffAddKey, v, seq, sig: buffSig}, (putErr, hash, number) => {
                     if(putErr){

--- a/main.js
+++ b/main.js
@@ -525,6 +525,9 @@ class Main {
     }
 
     // publish a new BEP46 torrent, or update an address/public key with a new torrent
+    // we need a folder(string) passed in as an argument
+    // we check we have a torrent already for the public key address
+    // we then copy the data from the folder to the this._internal directory
     // we return secret key along with the torrent because the user will need it
     async publishAddress(folder, keypair){
         if(!keypair || !keypair.address || !keypair.secret){

--- a/main.js
+++ b/main.js
@@ -260,7 +260,7 @@ class Main {
             })
         })
         if(!checkHash.test(getData.v.ih.toString('utf-8')) || !Number.isInteger(getData.seq)){
-            reject(new Error('data is invalid'))
+            throw new Error('data is invalid')
         }
         for(const prop in getData.v){
             getData.v[prop] = getData.v[prop].toString('utf-8')
@@ -287,12 +287,12 @@ class Main {
             const buffSecKey = secret ? Buffer.from(secret, 'hex') : null
             const v = text
       
-            let data = null
+            let main = null
             let seq = null
             if(await fs.pathExists(this._author + path.sep + address)){
-              data = await fs.readFile(this._author + path.sep + address)
-              data = JSON.parse(data.toString())
-              seq = data.sequence + 1
+              main = await fs.readFile(this._author + path.sep + address)
+              main = JSON.parse(data.toString())
+              seq = main.sequence + 1
             } else {
               seq = 0
             }
@@ -309,7 +309,7 @@ class Main {
                 })
             })
             let {ih, ...stuff} = text
-            let main = {magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: seq, stuff, sig: buffSig.toString('hex'), side: true, ...putData}
+            main = {magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: seq, stuff, sig: buffSig.toString('hex'), side: true, ...putData}
             await fs.writeFile(this._author + path.sep + address, JSON.stringify(main))
             return main
       }
@@ -777,6 +777,13 @@ class Main {
     }
 
     // -------------- the below functions are BEP46 helpders, especially bothGetPut which keeps the data active in the dht ----------------
+
+    // this function is used to keep data active in the dht
+    // torrent data is passed in as an argument
+    // it gets the most recent data from another user in the dht
+    // then puts that most recent data back into the dht
+    // if it  can not get the most recent data from another user
+    // then we put the torrent data that we currently have back into the dht
     bothGetPut(data){
         return new Promise((resolve, reject) => {
           const buffAddKey = Buffer.from(data.address, 'hex')

--- a/main.js
+++ b/main.js
@@ -139,7 +139,6 @@ async startUp () {
               checkTorrent[prop] = checkProperty[prop]
             }
             checkTorrent.folder = folderPath
-            checkTorrent.side = true
             console.log(checkInternalPath + ' is good')
           }
         }
@@ -155,7 +154,6 @@ async startUp () {
         if (checkTorrent) {
           checkTorrent.folder = folderPath
           checkTorrent.hash = checkInternalPath
-          checkTorrent.side = true
           console.log(checkInternalPath + ' is good')
         }
       } else {
@@ -200,7 +198,6 @@ async startUp () {
           ])
           if (checkTorrent) {
             checkTorrent.folder = folderPath
-            checkTorrent.side = false
             // don't overwrite the torrent's infohash even though they will both be the same
             delete checkProperty.infoHash
             for (const prop in checkProperty) {
@@ -220,7 +217,6 @@ async startUp () {
         ])
         if (checkTorrent) {
           checkTorrent.folder = folderPath
-          checkTorrent.side = false
           checkTorrent.hash = checkExternalPath
           console.log(checkExternalPath + ' is good')
         }
@@ -296,7 +292,7 @@ delayTimeOut(timeout, data, res){
       getData.v[prop] = getData.v[prop].toString('utf-8')
     }
     const { ih, ...stuff } = getData.v
-    return { magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: getData.seq, stuff, sig: getData.sig.toString('hex'), side: false, from: getData.id.toString('hex') }
+    return { magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: getData.seq, stuff, sig: getData.sig.toString('hex'), from: getData.id.toString('hex') }
   }
 
   // publish an infohash under a public key address in the dht
@@ -339,7 +335,7 @@ delayTimeOut(timeout, data, res){
       })
     })
     const { ih, ...stuff } = text
-    main = { magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: seq, stuff, sig: buffSig.toString('hex'), side: true, ...putData }
+    main = { magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: seq, stuff, sig: buffSig.toString('hex'), ...putData }
     await fs.writeFile(this._author + path.sep + address, JSON.stringify(main))
     return main
   }
@@ -373,7 +369,6 @@ delayTimeOut(timeout, data, res){
     ])
     checkTorrent.folder = folderPath
     checkTorrent.hash = hash
-    checkTorrent.side = true
     return checkTorrent
   }
 
@@ -416,7 +411,6 @@ delayTimeOut(timeout, data, res){
     // don't overwrite the torrent's infohash even though they will both be the same
     delete checkProperty.infoHash
     checkProperty.folder = folderPath
-    checkProperty.side = true
     for (const prop in checkProperty) {
       checkTorrent[prop] = checkProperty[prop]
     }
@@ -440,7 +434,6 @@ delayTimeOut(timeout, data, res){
       })
     ])
     checkTorrent.folder = folderPath
-    checkTorrent.side = false
     checkTorrent.hash = checkTorrent.infoHash
     return checkTorrent
   }
@@ -480,7 +473,6 @@ delayTimeOut(timeout, data, res){
     ])
     checkTorrent.folder = folderPath
     checkTorrent.hash = hash
-    checkTorrent.side = true
     return { torrent: checkTorrent, hash: checkTorrent.hash }
   }
 
@@ -496,7 +488,6 @@ delayTimeOut(timeout, data, res){
     ])
 
     checkProperty.folder = path.join(this._external, checkProperty.address)
-    checkProperty.side = false
 
     // if current option is true, then if the infohash for the address is brand new then empty the directory and download the new infohash
     // if the current option is false, then at least make sure the main folder which is named with the public key address exists
@@ -585,7 +576,6 @@ delayTimeOut(timeout, data, res){
     // don't overwrite the torrent's infohash even though they will both be the same
     delete checkProperty.infoHash
     checkProperty.folder = folderPath
-    checkProperty.side = true
     for (const prop in checkProperty) {
       checkTorrent[prop] = checkProperty[prop]
     }
@@ -697,7 +687,6 @@ delayTimeOut(timeout, data, res){
     const checkedTorrent = this.findTheAddress(address)
     if (checkedTorrent) {
       const folder = checkedTorrent.folder
-      // const side = checkedTorrent.side
       this.webtorrent.remove(checkedTorrent.infoHash, { destroyStore: false })
       if (folder) {
         try {
@@ -706,13 +695,6 @@ delayTimeOut(timeout, data, res){
           console.log(error)
         }
       }
-      // if (side) {
-      //   try {
-      //     await fs.remove(this._author + path.sep + address)
-      //   } catch (error) {
-      //     console.log(error)
-      //   }
-      // }
     } else {
       if (await fs.pathExists(path.join(this._external, address))) {
         try {

--- a/main.js
+++ b/main.js
@@ -460,6 +460,10 @@ delayTimeOut(timeout, data, res){
     }
     const folderPath = path.join(this._internal, hash)
     await fs.ensureDir(folderPath)
+    // await Promise.race([
+    //   this.delayTimeOut(this._timeout, new Error('took too long to write to disk'), false),
+    //   this.handleFormData(folderPath, headers, data)
+    // ])
     await this.handleFormData(folderPath, headers, data)
     const checkFolderPath = await fs.readdir(folderPath, {withFileTypes: false})
     if(!checkFolderPath.length){
@@ -543,6 +547,10 @@ delayTimeOut(timeout, data, res){
     }
     const folderPath = path.join(this._internal, keypair.address)
     await fs.ensureDir(folderPath)
+    // await Promise.race([
+    //   this.delayTimeOut(this._timeout, new Error('took too long to write to disk'), false),
+    //   this.handleFormData(folderPath, headers, data)
+    // ])
     await this.handleFormData(folderPath, headers, data)
     const checkFolderPath = await fs.readdir(folderPath, {withFileTypes: false})
     if(!checkFolderPath.length){

--- a/main.js
+++ b/main.js
@@ -456,7 +456,7 @@ delayTimeOut(timeout, data, res){
     if(hash){
       this.stopHash(hash)
     } else {
-      hash = crypto.createHash('sha1').update(crypto.randomBytes(20).toString('hex')).digest('hex')
+      hash = crypto.randomBytes(20).toString('hex')
     }
     const folderPath = path.join(this._internal, hash)
     await fs.ensureDir(folderPath)
@@ -603,6 +603,42 @@ delayTimeOut(timeout, data, res){
   // }
 
   // stops the torrent with the 40 character infohash(string)
+  shredHash (hash) {
+    const checkTorrent = this.findTheHash(hash)
+    if (checkTorrent) {
+      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: true })
+      return true
+    } else {
+      return false
+    }
+  }
+
+  shredAddress (address) {
+    const checkTorrent = this.findTheAddress(address)
+    if (checkTorrent) {
+      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: true })
+      return true
+    } else {
+      return false
+    }
+    // let result = null
+    // const checkTorrent = this.findTheAddress(address)
+    // if (checkTorrent) {
+    //   this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: true })
+    //   result = true
+    // } else {
+    //   if(await fs.pathExists(path.join(this._external, address))){
+    //     await fs.remove(path.join(this._external, address))
+    //     result = true
+    //   }
+    //   if(await fs.pathExists(path.join(this._internal, address))){
+    //     await fs.remove(path.join(this._internal, address))
+    //     result = true
+    //   }
+    // }
+    // return result
+  }
+
   stopHash (hash) {
     const checkTorrent = this.findTheHash(hash)
     if (checkTorrent) {
@@ -692,14 +728,15 @@ delayTimeOut(timeout, data, res){
           console.log(error)
         }
       }
-      if (await fs.pathExists(this._author + path.sep + address)) {
-        await fs.remove(this._author + path.sep + address)
-      }
+      // if (await fs.pathExists(this._author + path.sep + address)) {
+      //   await fs.remove(this._author + path.sep + address)
+      // }
     }
     return address + ' was removed'
   }
 
   // --------------------- the below functions loops and gets the torrents we are seeking, if it is not found then null is returned
+
   findTheFolder (folder) {
     let tempTorrent = null
     for (let i = 0; i < this.webtorrent.torrents.length; i++) {

--- a/main.js
+++ b/main.js
@@ -355,10 +355,10 @@ delayTimeOut(timeout, data, res){
 
   // we use this function to seed a non-BEP46 torrent that we have already created before, not really needed but here just for consistency
   async currentHash (hash) {
-    const haveTorrent = this.findTheHash(hash)
-    if (haveTorrent) {
-      return haveTorrent
-    }
+    // const haveTorrent = this.findTheHash(hash)
+    // if (haveTorrent) {
+    //   return haveTorrent
+    // }
     const folderPath = path.join(this._internal, hash)
     if (!await fs.pathExists(folderPath)) {
       throw new Error('folder does not exist')
@@ -379,10 +379,10 @@ delayTimeOut(timeout, data, res){
 
   // we must use this function to seed a BEP46 torrent that we have already published before
   async currentAddress (address) {
-    const haveTorrent = this.findTheAddress(address)
-    if (haveTorrent) {
-      return haveTorrent
-    }
+    // const haveTorrent = this.findTheAddress(address)
+    // if (haveTorrent) {
+    //   return haveTorrent
+    // }
     const folderPath = path.join(this._internal, address)
     if (!await fs.pathExists(folderPath)) {
       throw new Error('folder does not exist')
@@ -425,17 +425,12 @@ delayTimeOut(timeout, data, res){
 
   // download a regular non-BEP46 non-user created torrent by entering a 40 character infohash
   async loadHash (hash) {
-    const haveTorrent = this.findTheHash(hash)
-    if (haveTorrent) {
-      return haveTorrent
-    }
+    // const haveTorrent = this.findTheHash(hash)
+    // if (haveTorrent) {
+    //   return haveTorrent
+    // }
     // if user had torrent before, then empty the folder so previous data does not conflict with the infohash
     const folderPath = path.join(this._external, hash)
-    // try {
-    //     await fs.emptyDir(folderPath)
-    // } catch (error) {
-    //     console.log(error)
-    // }
     const checkTorrent = await Promise.race([
       this.delayTimeOut(this._timeout, new Error(hash + ' took too long, it timed out'), false),
       new Promise((resolve, reject) => {
@@ -487,10 +482,10 @@ delayTimeOut(timeout, data, res){
 
   // download a non-user created BEP46 torrent by their public key address, non-user meaning someone else's BEP46 torrent
   async loadAddress (address) {
-    const haveTorrent = this.findTheAddress(address)
-    if (haveTorrent) {
-      return haveTorrent
-    }
+    // const haveTorrent = this.findTheAddress(address)
+    // if (haveTorrent) {
+    //   return haveTorrent
+    // }
     const checkProperty = await Promise.race([
       this.delayTimeOut(this._timeout, new Error(address + ' property took too long, it timed out'), false),
       this.resolveFunc(address)
@@ -592,12 +587,12 @@ delayTimeOut(timeout, data, res){
   // ------------- the below functions are for stopping or removing data and torrents
 
   // stops all torrents
-  clearData () {
-    for (let i = 0; i < this.webtorrent.torrents.length; i++) {
-      this.webtorrent.remove(this.webtorrent.torrents[i].infoHash, { destroyStore: false })
-    }
-    return 'data was stopped'
-  }
+  // clearData () {
+  //   for (let i = 0; i < this.webtorrent.torrents.length; i++) {
+  //     this.webtorrent.remove(this.webtorrent.torrents[i].infoHash, { destroyStore: false })
+  //   }
+  //   return 'data was stopped'
+  // }
 
   // stops the torrent with the 40 character infohash(string)
   stopHash (hash) {
@@ -658,7 +653,7 @@ delayTimeOut(timeout, data, res){
     const checkedTorrent = this.findTheAddress(address)
     if (checkedTorrent) {
       const folder = checkedTorrent.folder
-      const side = checkedTorrent.side
+      // const side = checkedTorrent.side
       this.webtorrent.remove(checkedTorrent.infoHash, { destroyStore: false })
       if (folder) {
         try {
@@ -667,13 +662,13 @@ delayTimeOut(timeout, data, res){
           console.log(error)
         }
       }
-      if (side) {
-        try {
-          await fs.remove(this._author + path.sep + address)
-        } catch (error) {
-          console.log(error)
-        }
-      }
+      // if (side) {
+      //   try {
+      //     await fs.remove(this._author + path.sep + address)
+      //   } catch (error) {
+      //     console.log(error)
+      //   }
+      // }
     } else {
       if (await fs.pathExists(path.join(this._external, address))) {
         try {

--- a/main.js
+++ b/main.js
@@ -298,7 +298,6 @@ class Main {
             }
 
             const buffSig = ed.sign(encodeSigData({seq, v}), buffAddKey, buffSecKey)
-
             
             let putData = await new Promise((resolve, reject) => {
                 this.webtorrent.dht.put({k: buffAddKey, v, seq, sig: buffSig}, (putErr, hash, number) => {

--- a/main.js
+++ b/main.js
@@ -8,16 +8,23 @@ const bencode = require('bencode')
 // const EventEmitter = require('events').EventEmitter
 
 const BTPK_PREFIX = 'urn:btpk:'
+
+// saves us from saving secret keys(saving secret keys even encrypted secret keys is something i want to avoid)
+// with this function which was taken from the bittorrent-dht package
+// we save only the signatures when we first publish a BEP46 torrent
 function encodeSigData (msg) {
   const ref = { seq: msg.seq, v: msg.v }
   if (msg.salt) ref.salt = msg.salt
   return bencode.encode(ref).slice(1, -1)
 }
+
+// setting up constants
 const checkHash = new RegExp('^[a-fA-F0-9]{40}$')
 const checkAddress = new RegExp('^[a-fA-F0-9]{64}$')
 const checkTitle = new RegExp('^[a-f0-9]{32}$')
 const defOpts = {folder: __dirname, storage: 'storage', author: 'author', external: 'external', internal: 'internal', timeout: 60000, share: false, current: true, initial: true}
 
+// keep data active in the dht, runs every hour
 async function keepUpdated(self){
     self._readyToGo = false
     for(let i = 0;i < self.webtorrent.torrents.length;i++){
@@ -33,7 +40,12 @@ async function keepUpdated(self){
     self._readyToGo = true
 }
 
+//-------------------------------------
+// start up functions runs on every start up
+//-------------------------------------------
 async function startUp(self){
+    // a mechanism to clear all data meaning delete all user-created torrents, all non-user created torrents, and all BEP46 publishing data, most likely too extreme and not needed
+
     // if(self._status.clear){
     //     try {
     //         await fs.emptyDir(self._external)
@@ -43,14 +55,13 @@ async function startUp(self){
     //         console.log(error)
     //     }
     // }
+
+    // if initial option is true, then start seeding all user created torrents on start up
     if(self._status.initial){
         let checkInternal = await fs.readdir(self._internal, {withFileTypes: false})
         for(let i = 0;i < checkInternal.length;i++){
             let folderPath = self._internal + path.sep + checkInternal[i]
             if(checkAddress.test(checkInternal[i])){
-                // if(self.findTheAddress(checkInternal[i])){
-                //     continue
-                // }
                 let checkTorrent = await Promise.any([
                     new Promise((resolve, reject) => {
                         setTimeout(() => {resolve(null)}, self._status.timeout)
@@ -86,9 +97,6 @@ async function startUp(self){
                     }
                 }
             } else if(checkTitle.test(checkInternal[i])){
-                // if(self.findTheTitle(checkInternal[i])){
-                //     continue
-                // }
                 let checkTorrent = await Promise.any([
                     new Promise((resolve, reject) => {
                         setTimeout(() => {resolve(null)}, self._status.timeout)
@@ -110,14 +118,13 @@ async function startUp(self){
             }
         }
     }
+
+    // if share option is true, then start seeding(webtorrent.add seeds after torrent is downloaded) on start up
     if(self._status.share){
         let checkExternal = await fs.readdir(self._external, {withFileTypes: false})
         for(let i = 0;i < checkExternal.length;i++){
             let folderPath = self._external + path.sep + checkExternal[i]
             if(checkAddress.test(checkExternal[i])){
-                // if(self.findTheAddress(checkExternal[i])){
-                //     continue
-                // }
                 let checkProperty = await Promise.any([
                     new Promise((resolve, reject) => {setTimeout(() => {resolve(null)}, self._status.timeout)}),
                     self.resolve(checkExternal[i])
@@ -157,9 +164,6 @@ async function startUp(self){
                     }
                 }
             } else if(checkHash.test(checkExternal[i])){
-                // if(self.findTheHash(checkExternal[i])){
-                //     continue
-                // }
                 let checkTorrent = await Promise.any([
                     new Promise((resolve, reject) => {setTimeout(() => {resolve(null)}, self._status.timeout)}),
                     new Promise((resolve, reject) => {
@@ -209,7 +213,11 @@ class Main {
             console.log(error)
         })
         this._readyToGo = true
+
+        // run the start up function
         startUp(this).catch(error => {console.log(error)})
+
+        // run the keepUpdated function every 1 hour, it keep the data active by putting the data back into the dht, don't run it if it is still working from the last time it ran the keepUpdated function
         setInterval(() => {
             if(this._readyToGo){
                 keepUpdated(this).catch(error => {console.log(error)})
@@ -217,6 +225,9 @@ class Main {
         }, 3600000)
     }
 
+    // when we resume or seed a user created BEP46 torrent that has already been created before
+    // we have to check that the infohash of the torrent(remember we do not know the infohash before) matches the signature
+    // if it does not match, that means the data/torrent has been corrupted somehow
     async ownData(address, infoHash){
         if(!await fs.pathExists(this._author + path.sep + address)){
             throw new Error('data was not found')
@@ -229,46 +240,46 @@ class Main {
         return data
       }
 
-    async resolve(address){
+      // resolve public key address to an infohash
+      async resolveFunc(address){
         if(!address || typeof(address) !== 'string'){
             throw new Error('address can not be parsed')
         }
         const addressKey = Buffer.from(address, 'hex')
-        return await new Promise((resolve, reject) => {
+        let getData = await new Promise((resolve, reject) => {
             sha1(addressKey, (targetID) => {
                 this.webtorrent.dht.get(targetID, (err, res) => {
                     if(err){
-                    reject(err)
+                        reject(err)
                     } else if(res){
-                    if(!checkHash.test(res.v.ih.toString('utf-8')) || !Number.isInteger(res.seq)){
-                        reject(new Error('data is invalid'))
-                    }
-                    for(const prop in res.v){
-                        res.v[prop] = res.v[prop].toString('utf-8')
-                    }
-                    let {ih, ...stuff} = res.v
-                    resolve({magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: res.seq, stuff, sig: res.sig.toString('hex'), side: false, netdata: res})
+                        resolve(res)
                     } else if(!res){
-                    reject(new Error('Could not resolve address'))
+                        reject(new Error('Could not resolve address'))
                     }
                 })
             })
         })
+        if(!checkHash.test(getData.v.ih.toString('utf-8')) || !Number.isInteger(getData.seq)){
+            reject(new Error('data is invalid'))
+        }
+        for(const prop in getData.v){
+            getData.v[prop] = getData.v[prop].toString('utf-8')
+        }
+        let {ih, ...stuff} = getData.v
+        return {magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: getData.seq, stuff, sig: getData.sig.toString('hex'), side: false, from: getData.id.toString('hex')}
       }
 
-      async publish(address, secret, text){
+      // publish an infohash under a public key address in the dht
+      async publishFunc(address, secret, text){
             for(let prop in text){
               if(typeof(text[prop]) !== 'string'){
-                this.webtorrent.remove(text.ih, {destroyStore: false})
                 throw new Error('text data must be strings')
               }
             }
             if(!checkHash.test(text.ih)){
-                this.webtorrent.remove(text.ih, {destroyStore: false})
               throw new Error('must have infohash')
             }
             if(!address || !secret){
-                this.webtorrent.remove(text.ih, {destroyStore: false})
               throw new Error('must have address and secret')
             }
         
@@ -289,7 +300,6 @@ class Main {
             let putData = await new Promise((resolve, reject) => {
                 this.webtorrent.dht.put({k: buffAddKey, v, seq, sig: buffSig}, (putErr, hash, number) => {
                     if(putErr){
-                        this.webtorrent.remove(text.ih, {destroyStore: false})
                         reject(putErr)
                     } else {
                         resolve({hash: hash.toString('hex'), number})
@@ -302,7 +312,469 @@ class Main {
             return main
       }
 
-      bothGetPut(data){
+    // async shred(address){
+    //     if(await fs.pathExists(this._author + path.sep + address)){
+    //       await fs.remove(this._author + path.sep + address)
+    //       return true
+    //     } else {
+    //       return false
+    //     }
+    //   }
+
+    // we use this function to seed a non-BEP46 torrent that we have already created before, not really needed but here just for consistency
+    async currentTitle(title){
+        let haveTorrent = this.findTheTitle(title)
+        if(haveTorrent){
+            return haveTorrent
+        }
+        let folderPath = this._internal + path.sep + title
+        if(!await fs.pathExists(folderPath)){
+            throw new Error('folder does not exist')
+        }
+        checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error(title + ' took too long, it timed out'))}, this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        checkTorrent.folder = folderPath
+        checkTorrent.title = title
+        checkTorrent.side = true
+        return checkTorrent
+    }
+
+    // we must use this function to seed a BEP46 torrent that we have already published before
+    async currentAddress(address){
+        let haveTorrent = this.findTheAddress(address)
+        if(haveTorrent){
+            return haveTorrent
+        }
+        let folderPath = this._internal + path.sep + address
+        if(!await fs.pathExists(folderPath)){
+            throw new Error('folder does not exist')
+        }
+        let checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error(address + ' took too long, it timed out'))}, this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        let checkProperty = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+                    reject(new Error(address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
+                },this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.ownData(address, checkTorrent.infoHash).then(res => {
+                    resolve(res)
+                }).catch(error => {
+                    console.log(error)
+                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+                    reject(error)
+                })
+            })
+        ])
+        delete checkProperty.infoHash
+        checkProperty.folder = folderPath
+        checkProperty.side = true
+        for(const prop in checkProperty){
+            checkTorrent[prop] = checkProperty[prop]
+        }
+        return checkTorrent
+    }
+
+    // download a regular non-BEP46 non-user created torrent by entering a 40 character infohash
+    async loadHash(hash){
+        let haveTorrent = this.findTheHash(hash)
+        if(haveTorrent){
+            return haveTorrent
+        }
+        // if user had torrent before, then empty the folder so previous data does not conflict with the infohash
+        let folderPath = this._external + path.sep + hash
+        // try {
+        //     await fs.emptyDir(folderPath)
+        // } catch (error) {
+        //     console.log(error)
+        // }
+        checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error(hash + ' took too long, it timed out'))}, this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.add(hash, {path: folderPath, destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        checkTorrent.folder = folderPath
+        checkTorrent.side = false
+        checkTorrent.title = crypto.createHash('md5').update(hash).digest("hex")
+        return checkTorrent
+    }
+
+    // publish a regular non-BEP46 torrent, we need a path to the directory where the data is
+    // we copy it to a new sub-directory(inside the this._internal directory)
+    // that will have a 32 character md5 hash as it's sub-directory name
+    // we do this because we can not name it with the infohash
+    // because we do not know the infohash of this torrent beforehand
+    async publishTitle(folder){
+        if(!folder || typeof(folder) !== 'string'){
+            throw new Error('path ' + folder + ' does not work')
+        } else {
+            folder = {oldFolder: path.resolve(folder)}
+            folder.target = path.basename(folder.oldFolder)
+            folder.hashed = crypto.createHash('md5').update(folder.oldFolder).digest("hex")
+            folder.main = this._internal + path.sep + folder.hashed
+            folder.newFolder = folder.target.includes('.') ? folder.main + path.sep + folder.target : folder.main
+            let haveTorrent = this.findTheTitle(folder.hashed)
+            if(haveTorrent){
+                return {torrent: haveTorrent, title: haveTorrent.title}
+            }
+            if(folder.target.includes('.')){
+                try {
+                    await fs.emptyDir(folder.main)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            await fs.copy(folder.oldFolder, folder.newFolder, {overwrite: true})
+        }
+        let checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error('torrent took too long, it timed out'))}, this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.seed(folder.main, {destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        checkTorrent.folder = folder.main
+        checkTorrent.title = folder.hashed
+        checkTorrent.side = true
+        return {torrent: checkTorrent, title: checkTorrent.title}
+    }
+
+    // download a non-user created BEP46 torrent by their public key address, non-user meaning someone else's BEP46 torrent
+    async loadAddress(address){
+        let haveTorrent = this.findTheAddress(address)
+        if(haveTorrent){
+            return haveTorrent
+        }
+        let checkProperty = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error(address + ' property took too long, it timed out'))}, this._status.timeout)
+            }),
+            this.resolveFunc(address)
+        ])
+
+        checkProperty.folder = this._external + path.sep + checkProperty.address
+        checkProperty.side = false
+
+        // if current option is true, then if the infohash for the address is brand new then empty the directory and download the new infohash
+        // if the current option is false, then at least make sure the main folder which is named with the public key address exists
+        if(this._status.current){
+            if(!await fs.pathExists(checkProperty.folder + path.sep + checkProperty.infoHash)){
+                try {
+                    await fs.emptyDir(checkProperty.folder)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        } else if(!this._status.current){
+            if(!await fs.pathExists(checkProperty.folder)){
+                try {
+                    await fs.ensureDir(checkProperty.folder)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        }
+
+        let checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error(checkProperty.address + ' took too long, it timed out'))}, this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.add(checkProperty.infoHash, {path: checkProperty.folder + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        delete checkProperty.infoHash
+        for(const prop in checkProperty){
+            checkTorrent[prop] = checkProperty[prop]
+        }
+        return checkTorrent
+    }
+
+    // publish a new BEP46 torrent, or update an address/public key with a new torrent
+    async publishAddress(folder, keypair){
+        if(!keypair || !keypair.address || !keypair.secret){
+            keypair = this.createKeypair()
+        } else {
+            let haveTorrent = this.findTheAddress(keypair.address)
+            if(haveTorrent){
+                return {torrent: haveTorrent, secret: null}
+            }
+        }
+        if(!folder || typeof(folder) !== 'string'){
+            throw new Error('must have folder')
+        } else {
+            folder = {oldFolder: path.resolve(folder)}
+            folder.main = this._internal + path.sep + keypair.address
+            folder.target = path.basename(folder.oldFolder)
+            folder.newFolder = folder.target.includes('.') ? folder.main + path.sep + folder.target : folder.main
+            if(folder.target.includes('.')){
+                try {
+                    await fs.emptyDir(folder.main)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            await fs.copy(folder.oldFolder, folder.newFolder, {overwrite: true})
+        }
+        let checkTorrent = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {reject(new Error('torrent took too long, it timed out'))},this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.webtorrent.seed(folder.main, {destroyStoreOnDestroy: true}, torrent => {
+                    resolve(torrent)
+                })
+            })
+        ])
+        let checkProperty = await Promise.race([
+            new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+                    reject(new Error(keypair.address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
+                },this._status.timeout)
+            }),
+            new Promise((resolve, reject) => {
+                this.publishFunc(keypair.address, keypair.secret, {ih: checkTorrent.infoHash}).then(res => {
+                    resolve(res)
+                }).catch(error => {
+                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+                    reject(error)
+                })
+            })
+        ])
+        const tempSecret = checkProperty.secret
+        delete checkProperty.infoHash
+        delete checkProperty.secret
+        checkProperty.folder = folder.main
+        checkProperty.side = true
+        for(const prop in checkProperty){
+            checkTorrent[prop] = checkProperty[prop]
+        }
+        return {torrent: checkTorrent, secret: tempSecret}
+    }
+    
+    // ------------- the below functions are for stopping or removing data and torrents
+
+    // stops all torrents
+    clearData(){
+        for(let i = 0;i < this.webtorrent.torrents.length;i++){
+            this.webtorrent.remove(this.webtorrent.torrents[i].infoHash, {destroyStore: false})
+        }
+        return 'data was stopped'
+    }
+
+    // stops the torrent with the title(string), title is a 32 character md5 hash used for the directory name of a non-BEP46 user created torrent aka regular torrent
+    stopTitle(title){
+        let checkTorrent = this.findTheTitle(title)
+        if(checkTorrent){
+            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+            return title + ' was stopped'
+        } else {
+            return title + ' was not found'
+        }
+    }
+
+    // stops the torrent with the 40 character infohash(string)
+    stopHash(hash){
+        let checkTorrent = this.findTheHash(hash)
+        if(checkTorrent){
+            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+            return hash + ' was stopped'
+        } else {
+            return hash + ' was not found'
+        }
+    }
+
+    // stops the torrent with the 64 character public key(string)
+    stopAddress(address){
+        let checkTorrent = this.findTheAddress(address)
+        if(checkTorrent){
+            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+            return address + ' was stopped'   
+        } else {
+            return address + ' was not found'
+        }
+    }
+
+    // stop the torrent with the title, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
+    async removeTitle(title){
+        let checkTorrent = this.findTheTitle(title)
+        if(checkTorrent){
+            let folder = checkTorrent.folder
+            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+            if(folder){
+                try {
+                    await fs.remove(folder)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        } else {
+            if(await fs.pathExists(this._external + path.sep + title)){
+                try {
+                    await fs.remove(this._external + path.sep + title)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            if(await fs.pathExists(this._internal + path.sep + title)){
+                try {
+                    await fs.remove(this._internal + path.sep + title)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        }
+        return title + ' has been removed'
+    }
+
+    // stop the torrent with the infohash, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
+    async removeHash(hash){
+        let checkTorrent = this.findTheHash(hash)
+        if(checkTorrent){
+            let folder = checkTorrent.folder
+            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
+            if(folder){
+                try {
+                    await fs.remove(folder)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        } else {
+            if(await fs.pathExists(this._external + path.sep + hash)){
+                try {
+                    await fs.remove(this._external + path.sep + hash)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            if(await fs.pathExists(this._internal + path.sep + hash)){
+                try {
+                    await fs.remove(this._internal + path.sep + hash)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        }
+        return hash + ' has been removed'
+    }
+
+    // stop the torrent with the address, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
+    async removeAddress(address){
+        let checkedTorrent = this.findTheAddress(address)
+        if(checkedTorrent){
+            let folder = checkedTorrent.folder
+            let side = checkedTorrent.side
+            this.webtorrent.remove(checkedTorrent.infoHash, {destroyStore: false})
+            if(folder){
+                try {
+                    await fs.remove(folder)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            if(side){
+                try {
+                    await fs.remove(this._author + path.sep + address)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+        } else {
+            if(await fs.pathExists(this._external + path.sep + address)){
+                try {
+                    await fs.remove(this._external + path.sep + address)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            if(await fs.pathExists(this._internal + path.sep + address)){
+                try {
+                    await fs.remove(this._internal + path.sep + address)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
+            if(await fs.pathExists(this._author + path.sep + address)){
+                await fs.remove(this._author + path.sep + address)
+              }
+        }
+        return address + ' was removed'
+    }
+
+    // --------------------- the below functions loops and gets the torrents we are seeking, if it is not found then null is returned
+    findTheFolder(folder){
+        let tempTorrent = null
+        for(let i = 0;i < this.webtorrent.torrents.length;i++){
+            if(this.webtorrent.torrents[i].folder === folder){
+                tempTorrent = this.webtorrent.torrents[i]
+                break
+            }
+        }
+        return tempTorrent
+    }
+    findTheTitle(title){
+        let tempTorrent = null
+        for(let i = 0;i < this.webtorrent.torrents.length;i++){
+            if(this.webtorrent.torrents[i].title === title){
+                tempTorrent = this.webtorrent.torrents[i]
+                break
+            }
+        }
+        return tempTorrent
+    }
+    findTheHash(hash){
+        let tempTorrent = null
+        for(let i = 0;i < this.webtorrent.torrents.length;i++){
+            if(this.webtorrent.torrents[i].infoHash === hash){
+                tempTorrent = this.webtorrent.torrents[i]
+                break
+            }
+        }
+        return tempTorrent
+    }
+    findTheAddress(address){
+        let tempTorrent = null
+        for(let i = 0;i < this.webtorrent.torrents.length;i++){
+            if(this.webtorrent.torrents[i].address === address){
+                tempTorrent = this.webtorrent.torrents[i]
+                break
+            }
+        }
+        return tempTorrent
+    }
+
+    // -------------- the below functions are BEP46 helpders, especially bothGetPut which keeps the data active in the dht ----------------
+    bothGetPut(data){
         return new Promise((resolve, reject) => {
           const buffAddKey = Buffer.from(data.address, 'hex')
           const buffSigData = Buffer.from(data.sig, 'hex')
@@ -416,434 +888,6 @@ class Main {
           return ''
         }
       }
-
-    async shred(address){
-        if(await fs.pathExists(this._author + path.sep + address)){
-          await fs.remove(this._author + path.sep + address)
-          return true
-        } else {
-          return false
-        }
-      }
-
-    async ownTitle(title){
-        let haveTorrent = this.findTheTitle(title)
-        if(haveTorrent){
-            return haveTorrent
-        }
-        let folderPath = this._internal + path.sep + title
-        if(!await fs.pathExists(folderPath)){
-            throw new Error('folder does not exist')
-        }
-        checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error(title + ' took too long, it timed out'))}, this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        checkTorrent.folder = folderPath
-        checkTorrent.title = title
-        checkTorrent.side = true
-        return checkTorrent
-    }
-
-    async ownAddress(address){
-        let haveTorrent = this.findTheAddress(address)
-        if(haveTorrent){
-            return haveTorrent
-        }
-        let folderPath = this._internal + path.sep + address
-        if(!await fs.pathExists(folderPath)){
-            throw new Error('folder does not exist')
-        }
-        let checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error(address + ' took too long, it timed out'))}, this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.seed(folderPath, {destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        let checkProperty = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-                    reject(new Error(address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
-                },this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.ownData(address, checkTorrent.infoHash).then(res => {
-                    resolve(res)
-                }).catch(error => {
-                    console.log(error)
-                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-                    reject(error)
-                })
-            })
-        ])
-        delete checkProperty.infoHash
-        checkProperty.folder = folderPath
-        checkProperty.side = true
-        for(const prop in checkProperty){
-            checkTorrent[prop] = checkProperty[prop]
-        }
-        return checkTorrent
-    }
-
-    async loadHash(hash){
-        let haveTorrent = this.findTheHash(hash)
-        if(haveTorrent){
-            return haveTorrent
-        }
-        // if user had torrent before, then empty the folder so previous data does notconflict with the infohash
-        let folderPath = this._external + path.sep + hash
-        // try {
-        //     await fs.emptyDir(folderPath)
-        // } catch (error) {
-        //     console.log(error)
-        // }
-        checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error(hash + ' took too long, it timed out'))}, this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.add(hash, {path: folderPath, destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        checkTorrent.folder = folderPath
-        checkTorrent.side = false
-        checkTorrent.title = crypto.createHash('md5').update(hash).digest("hex")
-        return checkTorrent
-    }
-
-    async publishTitle(folder){
-        if(!folder || typeof(folder) !== 'string'){
-            throw new Error('path ' + folder + ' does not work')
-        } else {
-            folder = {oldFolder: path.resolve(folder)}
-            folder.target = path.basename(folder.oldFolder)
-            folder.hashed = crypto.createHash('md5').update(folder.oldFolder).digest("hex")
-            folder.main = this._internal + path.sep + folder.hashed
-            folder.newFolder = folder.target.includes('.') ? folder.main + path.sep + folder.target : folder.main
-            let haveTorrent = this.findTheTitle(folder.hashed)
-            if(haveTorrent){
-                return {torrent: haveTorrent, title: haveTorrent.title}
-            }
-            if(folder.target.includes('.')){
-                try {
-                    await fs.emptyDir(folder.main)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            await fs.copy(folder.oldFolder, folder.newFolder, {overwrite: true})
-        }
-        let checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error('torrent took too long, it timed out'))}, this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.seed(folder.main, {destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        checkTorrent.folder = folder.main
-        checkTorrent.title = folder.hashed
-        checkTorrent.side = true
-        return {torrent: checkTorrent, title: checkTorrent.title}
-    }
-
-    async loadAddress(address){
-        let haveTorrent = this.findTheAddress(address)
-        if(haveTorrent){
-            return haveTorrent
-        }
-        let checkProperty = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error(address + ' property took too long, it timed out'))}, this._status.timeout)
-            }),
-            this.resolve(address)
-        ])
-
-        checkProperty.folder = this._external + path.sep + checkProperty.address
-        checkProperty.side = false
-
-        // if user had this torrent before and data or files were added in this folder, then the site might be messed up, we empty the folder that way the infohash is intact
-        if(this._status.current){
-            if(!await fs.pathExists(checkProperty.folder + path.sep + checkProperty.infoHash)){
-                try {
-                    await fs.emptyDir(checkProperty.folder)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        } else if(!this._status.current){
-            if(!await fs.pathExists(checkProperty.folder)){
-                try {
-                    await fs.ensureDir(checkProperty.folder)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        }
-
-        let checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error(checkProperty.address + ' took too long, it timed out'))}, this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.add(checkProperty.infoHash, {path: checkProperty.folder + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        delete checkProperty.infoHash
-        for(const prop in checkProperty){
-            checkTorrent[prop] = checkProperty[prop]
-        }
-        return checkTorrent
-    }
-    async publishAddress(folder, keypair){
-        if(!keypair || !keypair.address || !keypair.secret){
-            keypair = this.createKeypair()
-        }
-        let haveTorrent = this.findTheAddress(keypair.address)
-        if(haveTorrent){
-            return {torrent: haveTorrent, secret: null}
-        }
-        if(!folder || typeof(folder) !== 'string'){
-            throw new Error('must have folder')
-        } else {
-            folder = {oldFolder: path.resolve(folder)}
-            folder.main = this._internal + path.sep + keypair.address
-            folder.target = path.basename(folder.oldFolder)
-            folder.newFolder = folder.target.includes('.') ? folder.main + path.sep + folder.target : folder.main
-            if(folder.target.includes('.')){
-                try {
-                    await fs.emptyDir(folder.main)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            await fs.copy(folder.oldFolder, folder.newFolder, {overwrite: true})
-        }
-        let checkTorrent = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {reject(new Error('torrent took too long, it timed out'))},this._status.timeout)
-            }),
-            new Promise((resolve, reject) => {
-                this.webtorrent.seed(folder.main, {destroyStoreOnDestroy: true}, torrent => {
-                    resolve(torrent)
-                })
-            })
-        ])
-        let checkProperty = await Promise.race([
-            new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-                    reject(new Error(keypair.address + ' property took too long, it timed out, please try again with only the keypair without the folder'))
-                },this._status.timeout)
-            }),
-            this.publish(keypair.address, keypair.secret, {ih: checkTorrent.infoHash})
-        ])
-        const tempSecret = checkProperty.secret
-        delete checkProperty.infoHash
-        delete checkProperty.secret
-        checkProperty.folder = folder.main
-        checkProperty.side = true
-        for(const prop in checkProperty){
-            checkTorrent[prop] = checkProperty[prop]
-        }
-        return {torrent: checkTorrent, secret: tempSecret}
-    }
-    
-    clearData(){
-        for(let i = 0;i < this.webtorrent.torrents.length;i++){
-            this.webtorrent.remove(this.webtorrent.torrents[i].infoHash, {destroyStore: false})
-        }
-        return 'data was stopped'
-    }
-
-    stopTitle(title){
-        let checkTorrent = this.findTheTitle(title)
-        if(checkTorrent){
-            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-            return title + ' was stopped'
-        } else {
-            return title + ' was not found'
-        }
-    }
-    
-    async removeTitle(title){
-        let checkTorrent = this.findTheTitle(title)
-        if(checkTorrent){
-            let folder = checkTorrent.folder
-            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-            if(folder){
-                try {
-                    await fs.remove(folder)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        } else {
-            if(await fs.pathExists(this._external + path.sep + title)){
-                try {
-                    await fs.remove(this._external + path.sep + title)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            if(await fs.pathExists(this._internal + path.sep + title)){
-                try {
-                    await fs.remove(this._internal + path.sep + title)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        }
-        return title + ' has been removed'
-    }
-
-    stopHash(hash){
-        let checkTorrent = this.findTheHash(hash)
-        if(checkTorrent){
-            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-            return hash + ' was stopped'
-        } else {
-            return hash + ' was not found'
-        }
-    }
-    
-    async removeHash(hash){
-        let checkTorrent = this.findTheHash(hash)
-        if(checkTorrent){
-            let folder = checkTorrent.folder
-            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-            if(folder){
-                try {
-                    await fs.remove(folder)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        } else {
-            if(await fs.pathExists(this._external + path.sep + hash)){
-                try {
-                    await fs.remove(this._external + path.sep + hash)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            if(await fs.pathExists(this._internal + path.sep + hash)){
-                try {
-                    await fs.remove(this._internal + path.sep + hash)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        }
-        return hash + ' has been removed'
-    }
-    stopAddress(address){
-        let checkTorrent = this.findTheAddress(address)
-        if(checkTorrent){
-            this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
-            return address + ' was stopped'   
-        } else {
-            return address + ' was not found'
-        }
-    }
-    async removeAddress(address){
-        let checkedTorrent = this.findTheAddress(address)
-        if(checkedTorrent){
-            let folder = checkedTorrent.folder
-            let side = checkedTorrent.side
-            this.webtorrent.remove(checkedTorrent.infoHash, {destroyStore: false})
-            if(folder){
-                try {
-                    await fs.remove(folder)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            if(side){
-                try {
-                    await fs.remove(this._author + path.sep + address)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-        } else {
-            if(await fs.pathExists(this._external + path.sep + address)){
-                try {
-                    await fs.remove(this._external + path.sep + address)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            if(await fs.pathExists(this._internal + path.sep + address)){
-                try {
-                    await fs.remove(this._internal + path.sep + address)
-                } catch (error) {
-                    console.log(error)
-                }
-            }
-            if(await fs.pathExists(this._author + path.sep + address)){
-                await fs.remove(this._author + path.sep + address)
-              }
-        }
-        return address + ' was removed'
-    }
-    findTheFolder(folder){
-        let tempTorrent = null
-        for(let i = 0;i < this.webtorrent.torrents.length;i++){
-            if(this.webtorrent.torrents[i].folder === folder){
-                tempTorrent = this.webtorrent.torrents[i]
-                break
-            }
-        }
-        return tempTorrent
-    }
-    findTheTitle(title){
-        let tempTorrent = null
-        for(let i = 0;i < this.webtorrent.torrents.length;i++){
-            if(this.webtorrent.torrents[i].title === title){
-                tempTorrent = this.webtorrent.torrents[i]
-                break
-            }
-        }
-        return tempTorrent
-    }
-    findTheHash(hash){
-        let tempTorrent = null
-        for(let i = 0;i < this.webtorrent.torrents.length;i++){
-            if(this.webtorrent.torrents[i].infoHash === hash){
-                tempTorrent = this.webtorrent.torrents[i]
-                break
-            }
-        }
-        return tempTorrent
-    }
-    findTheAddress(address){
-        let tempTorrent = null
-        for(let i = 0;i < this.webtorrent.torrents.length;i++){
-            if(this.webtorrent.torrents[i].address === address){
-                tempTorrent = this.webtorrent.torrents[i]
-                break
-            }
-        }
-        return tempTorrent
-    }
 }
 
 module.exports = Main

--- a/main.js
+++ b/main.js
@@ -572,15 +572,13 @@ class Main {
                 })
             })
         ])
-        const tempSecret = checkProperty.secret
         delete checkProperty.infoHash
-        delete checkProperty.secret
         checkProperty.folder = folder.main
         checkProperty.side = true
         for(const prop in checkProperty){
             checkTorrent[prop] = checkProperty[prop]
         }
-        return {torrent: checkTorrent, secret: tempSecret}
+        return {torrent: checkTorrent, secret: keypair.secret}
     }
     
     // ------------- the below functions are for stopping or removing data and torrents

--- a/main.js
+++ b/main.js
@@ -741,9 +741,9 @@ delayTimeOut(timeout, data, res){
         handleRemoval()
         stop()
       }
-      busboy.on('error', handleErrors)
-      busboy.on('close', handleClose)
-      busboy.on('file', handleFiles)
+      bb.on('error', handleErrors)
+      bb.on('close', handleClose)
+      bb.on('file', handleFiles)
 
       // TODO: Does busboy need to be GC'd?
       return () => {}

--- a/main.js
+++ b/main.js
@@ -429,6 +429,8 @@ class Main {
     // that will have a 32 character md5 hash as it's sub-directory name
     // we do this because we can not name it with the infohash
     // because we do not know the infohash of this torrent beforehand
+    // we return the torrent along with the title
+    // that way the user knows the title when they want to start the torrent
     async publishTitle(folder){
         if(!folder || typeof(folder) !== 'string'){
             throw new Error('path ' + folder + ' does not work')
@@ -521,6 +523,7 @@ class Main {
     }
 
     // publish a new BEP46 torrent, or update an address/public key with a new torrent
+    // we return secret key along with the torrent because the user will need it
     async publishAddress(folder, keypair){
         if(!keypair || !keypair.address || !keypair.secret){
             keypair = this.createKeypair()

--- a/main.js
+++ b/main.js
@@ -730,13 +730,14 @@ delayTimeOut(timeout, data, res){
       })
     })
     await fs.ensureDir(folderPath)
+    async function handleFiles(name, file, info){
+      await fs.writeFile(path.join(folderPath, info.filename), file)
+      // const saveTo = fs.createWriteStream(path.join(folderPath, info.filename));
+      // file.pipe(saveTo)
+    }
+    bb.on('file', handleFiles)
     await new Promise((resolve, reject) => {
-      function handleFiles(name, file, info){
-        fs.writeFile(path.join(folderPath, info.filename), file)
-        // const saveTo = fs.createWriteStream(path.join(folderPath, info.filename));
-        // file.pipe(saveTo)
-      }
-      bb.on('file', handleFiles)
+      // bb.on('file', handleFiles)
       bb.once('error', (error) => {
         bb.off('file', handleFiles)
         reject(error)

--- a/main.js
+++ b/main.js
@@ -759,7 +759,7 @@ delayTimeOut(timeout, data, res){
       function handleRemoval(){
         bb.off('file', handleFiles)
         bb.off('error', handleErrors)
-        bb.off('close', handleFinish)
+        bb.off('finish', handleFinish)
       }
       function handleFiles(name, file, info){
         // fs.writeFile(path.join(folderPath, info.filename), Readable.from(file))

--- a/main.js
+++ b/main.js
@@ -88,6 +88,7 @@ async function startUp(self){
                         })
                     ])
                     if(checkProperty){
+                        // don't overwrite the torrent's infohash even though they will both be the same
                         delete checkProperty.infoHash
                         for(const prop in checkProperty){
                             checkTorrent[prop] = checkProperty[prop]
@@ -157,6 +158,7 @@ async function startUp(self){
                     if(checkTorrent){
                         checkTorrent.folder = folderPath
                         checkTorrent.side = false
+                        // don't overwrite the torrent's infohash even though they will both be the same
                         delete checkProperty.infoHash
                         for(const prop in checkProperty){
                             checkTorrent[prop] = checkProperty[prop]
@@ -388,6 +390,7 @@ class Main {
                 })
             })
         ])
+        // don't overwrite the torrent's infohash even though they will both be the same
         delete checkProperty.infoHash
         checkProperty.folder = folderPath
         checkProperty.side = true
@@ -517,6 +520,7 @@ class Main {
                 })
             })
         ])
+        // don't overwrite the torrent's infohash even though they will both be the same
         delete checkProperty.infoHash
         for(const prop in checkProperty){
             checkTorrent[prop] = checkProperty[prop]
@@ -581,6 +585,7 @@ class Main {
                 })
             })
         ])
+        // don't overwrite the torrent's infohash even though they will both be the same
         delete checkProperty.infoHash
         checkProperty.folder = folder.main
         checkProperty.side = true

--- a/main.js
+++ b/main.js
@@ -381,6 +381,7 @@ class Main {
                     resolve(res)
                 }).catch(error => {
                     console.log(error)
+                    // if there is an error with publishing to the dht, then stop this torrent and reject the promise
                     this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
                     reject(error)
                 })
@@ -570,6 +571,7 @@ class Main {
                 this.publishFunc(keypair.address, keypair.secret, {ih: checkTorrent.infoHash}).then(res => {
                     resolve(res)
                 }).catch(error => {
+                    // if there is an error with publishing to the dht, then stop this torrent and reject the promise
                     this.webtorrent.remove(checkTorrent.infoHash, {destroyStore: false})
                     reject(error)
                 })
@@ -816,7 +818,8 @@ class Main {
         })
       }
     
-      saveData(data){
+      // keep the data we currently hold active by putting it back into the dht
+      keepData(data){
         return new Promise((resolve, reject) => {
           this.webtorrent.dht.put({k: Buffer.from(data.address, 'hex'), v: {ih: data.infoHash, ...data.stuff}, seq: data.sequence, sig: Buffer.from(data.sig, 'hex')}, (error, hash, number) => {
             if(error){
@@ -828,6 +831,7 @@ class Main {
         })
       }
     
+      // tries to get the data from another user and put that recent data back into the dht to keep the data active
       keepCurrent(address){
         return new Promise((resolve, reject) => {
           const buffAddKey = Buffer.from(address, 'hex')
@@ -853,12 +857,14 @@ class Main {
         })
       }
     
+      // create a keypair
       createKeypair () {
         let {publicKey, secretKey} = ed.createKeyPair(ed.createSeed())
     
         return { address: publicKey.toString('hex'), secret: secretKey.toString('hex') }
       }
     
+      // extract the public key/address out of a link
       addressFromLink(link){
         if(!link || typeof(link) !== 'string'){
           return ''

--- a/main.js
+++ b/main.js
@@ -56,17 +56,17 @@ class Main {
     }
     this.webtorrent = new WebTorrent({ dht: { verify: ed.verify } })
     this.webtorrent.on('error', error => {
-      console.log(error)
+      console.error(error)
     })
     this._readyToGo = true
 
     // run the start up function
-    this.startUp().catch(error => { console.log(error) })
+    this.startUp().catch(error => { console.error(error) })
 
     // run the keepUpdated function every 1 hour, it keep the data active by putting the data back into the dht, don't run it if it is still working from the last time it ran the keepUpdated function
     this.updateRoutine = setInterval(() => {
       if (this._readyToGo) {
-        this.keepUpdated().catch(error => { console.log(error) })
+        this.keepUpdated().catch(error => { console.error(error) })
       }
     }, 3600000)
   }
@@ -121,7 +121,7 @@ async startUp () {
               this.ownData(checkInternalPath, checkTorrent.infoHash).then(res => {
                 resolve(res)
               }).catch(error => {
-                console.log(error)
+                console.error(error)
                 // most likely the infohash of this torrent does not match what we have currently, stop this torrent
                 this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
                 resolve(null)
@@ -389,7 +389,7 @@ delayTimeOut(timeout, data, res = false){
         this.ownData(address, checkTorrent.infoHash).then(res => {
           resolve(res)
         }).catch(error => {
-          console.log(error)
+          console.error(error)
           // most likely the infohash of this torrent does not match what we have, stop this torrent and reject the promise
           this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
           reject(error)
@@ -758,7 +758,7 @@ delayTimeOut(timeout, data, res = false){
       sha1(buffAddKey, (targetID) => {
         this.webtorrent.dht.get(targetID, (getErr, getData) => {
           if (getErr) {
-            console.log(getErr)
+            console.error(getErr)
           }
           if (getData) {
             this.webtorrent.dht.put(getData, (putErr, hash, number) => {

--- a/main.js
+++ b/main.js
@@ -719,8 +719,8 @@ delayTimeOut(timeout, data, res){
   }
 
   async handleFormData(folderPath, headers, data){
-    const bb = busboy({ headers })
     await fs.ensureDir(folderPath)
+    const bb = busboy({ headers })
     
     const toUpload = new EventIterator(({ push, stop, fail }) => {
       function handleRemoval(){

--- a/package.json
+++ b/package.json
@@ -23,15 +23,13 @@
     "url": "https://github.com/RangerMauve/bt-fetch/issues"
   },
   "homepage": "https://github.com/RangerMauve/bt-fetch#readme",
-  "dependencies": {
-    "make-fetch": "^2.3.1",
-    "mime": "^2.5.2",
-    "range-parser": "^1.2.1",
-    "stream-async-iterator": "^2.0.0",
-    "webproperty": "^1.6.3",
-    "webtorrent": "^0.116.0"
-  },
   "devDependencies": {
     "tmp": "^0.2.1"
+  },
+  "dependencies": {
+    "btp-torrent": "^1.2.6",
+    "make-fetch": "^2.3.1",
+    "mime": "^3.0.0",
+    "stream-async-iterator": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bencode": "^2.0.2",
     "busboy": "^1.4.0",
     "ed25519-supercop": "^2.0.1",
+    "event-iterator": "^2.0.0",
     "fs-extra": "^10.0.0",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bt-fetch-torrent": "^1.3.4",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",
+    "range-parser": "^1.2.1",
     "stream-async-iterator": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tmp": "^0.2.1"
   },
   "dependencies": {
-    "bt-fetch-torrent": "^1.3.4",
+    "bt-fetch-torrent": "^1.3.5",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",
     "range-parser": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-fetch",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Interact with Bittorrent the same way you would websites via fetch()",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "tmp": "^0.2.1"
   },
   "dependencies": {
-    "btp-torrent": "^1.2.6",
+    "btp-torrent": "^1.2.7",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",
     "stream-async-iterator": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Interact with Bittorrent the same way you would websites via fetch()",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js",
+    "lint": "standard --fix"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,7 @@
   "homepage": "https://github.com/RangerMauve/bt-fetch#readme",
   "devDependencies": {
     "form-data": "^4.0.0",
+    "standard": "^17.0.0",
     "tape": "^5.5.0",
     "tmp-promise": "^3.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-fetch",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Interact with Bittorrent the same way you would websites via fetch()",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "tmp": "^0.2.1"
   },
   "dependencies": {
-    "btp-torrent": "^1.2.7",
+    "btp-torrent": "^1.2.8",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",
     "stream-async-iterator": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tmp": "^0.2.1"
   },
   "dependencies": {
-    "btp-torrent": "^1.2.8",
+    "bt-fetch-torrent": "^1.3.2",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",
     "stream-async-iterator": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   },
   "dependencies": {
     "bencode": "^2.0.2",
+    "busboy": "^1.4.0",
     "ed25519-supercop": "^2.0.1",
+    "event-iterator": "^2.0.0",
     "fs-extra": "^10.0.0",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-fetch",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Interact with Bittorrent the same way you would websites via fetch()",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Interact with Bittorrent the same way you would websites via fetch()",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test.js"
   },
   "repository": {
     "type": "git",
@@ -24,11 +24,14 @@
   },
   "homepage": "https://github.com/RangerMauve/bt-fetch#readme",
   "devDependencies": {
-    "tmp": "^0.2.1"
+    "form-data": "^4.0.0",
+    "tape": "^5.5.0",
+    "tmp-promise": "^3.0.3"
   },
   "dependencies": {
     "bencode": "^2.0.2",
     "busboy": "^1.4.0",
+    "derive-key": "^1.0.1",
     "ed25519-supercop": "^2.0.1",
     "fs-extra": "^10.0.0",
     "make-fetch": "^2.3.1",
@@ -36,6 +39,6 @@
     "range-parser": "^1.2.1",
     "simple-sha1": "^3.1.0",
     "stream-async-iterator": "^2.0.0",
-    "webtorrent": "^1.6.0"
+    "webtorrent": "^1.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tmp": "^0.2.1"
   },
   "dependencies": {
-    "bt-fetch-torrent": "^1.3.2",
+    "bt-fetch-torrent": "^1.3.3",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",
     "stream-async-iterator": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tmp": "^0.2.1"
   },
   "dependencies": {
-    "bt-fetch-torrent": "^1.3.5",
+    "bt-fetch-torrent": "^1.3.6",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",
     "range-parser": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "bencode": "^2.0.2",
     "busboy": "^1.4.0",
     "ed25519-supercop": "^2.0.1",
-    "event-iterator": "^2.0.0",
     "fs-extra": "^10.0.0",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tmp": "^0.2.1"
   },
   "dependencies": {
-    "bt-fetch-torrent": "^1.3.3",
+    "bt-fetch-torrent": "^1.3.4",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",
     "stream-async-iterator": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -27,10 +27,14 @@
     "tmp": "^0.2.1"
   },
   "dependencies": {
-    "bt-fetch-torrent": "^1.3.6",
+    "bencode": "^2.0.2",
+    "ed25519-supercop": "^2.0.1",
+    "fs-extra": "^10.0.0",
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",
     "range-parser": "^1.2.1",
-    "stream-async-iterator": "^2.0.0"
+    "simple-sha1": "^3.1.0",
+    "stream-async-iterator": "^2.0.0",
+    "webtorrent": "^1.6.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -45,7 +45,7 @@ test('Create a torrent using FormData to bittorrent://localhost/, check files', 
     const expectedFiles = ['example.txt', 'example2.txt'].sort()
     t.deepEqual(files.sort(), expectedFiles.sort(), 'Got listing of uploaded files')
 
-    for(const fileName of files) {
+    for (const fileName of files) {
       const fileURL = new URL(fileName, createdURL).href
       const getResponse = await fetch(fileURL)
       const fileData = await getResponse.text()
@@ -71,10 +71,6 @@ test('Create a torrent using FormData to petname', async (t) => {
     form.append('file', TEST_DATA, {
       filename: 'example2.txt'
     })
-    // TODO: Figure out subfolders, might only work for mutable torrents?
-    form.append('file', TEST_DATA, {
-      filename: 'foldler/example.md'
-    })
 
     const body = form.getBuffer()
     const headers = form.getHeaders()
@@ -95,8 +91,15 @@ test('Create a torrent using FormData to petname', async (t) => {
     const listResponse = await fetch(createdURL)
     t.ok(listResponse.ok, 'able to list directory')
     const files = await listResponse.json()
-    const expectedFiles = ['example.txt', 'example2.txt', 'example.md'].sort()
+    const expectedFiles = ['example.txt', 'example2.txt'].sort()
     t.deepEqual(files.sort(), expectedFiles.sort(), 'Got listing of uploaded files')
+
+    for (const fileName of files) {
+      const fileURL = new URL(fileName, createdURL).href
+      const getResponse = await fetch(fileURL)
+      const fileData = await getResponse.text()
+      t.equal(fileData, TEST_DATA, 'Got expected file data')
+    }
   } finally {
     await fetch.destroy()
   }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,152 @@
+const test = require('tape')
+const tmp = require('tmp')
+const FormData = require('form-data')
+const makeBTFetch = require('./')
+
+tmp.setGracefulCleanup()
+const folder = tmp.dirSync({ prefix: 'btfetch_example' }).name
+
+const TEST_DATA = 'Hello World!'
+
+test('Create a torrent using FormData to bittorrent://$/, check files', async (t) => {
+  const fetch = makeBTFetch({
+    folder
+  })
+
+  try {
+    const form = new FormData()
+
+    form.append('name', 'TestTorrent')
+    form.append('file2', TEST_DATA, {
+      filename: 'example.txt'
+    })
+    form.append('file', TEST_DATA, {
+      filename: 'example2.txt'
+    })
+    // TODO: Figure out subfolders, might only work for mutable torrents?
+    form.append('file', TEST_DATA, {
+      filename: 'foldler/example.md'
+    })
+
+    const body = form.getBuffer()
+    const headers = form.getHeaders()
+
+    const response = await fetch('bittorrent://$/', {
+      method: 'POST',
+      headers,
+      body
+    })
+
+    t.ok(response.ok, 'Successful response')
+    const createdURL = await response.text()
+
+    t.ok(createdURL.startsWith('bittorrent://'), 'got new bittorrent URL back')
+    t.equal(createdURL.length, 'bittorrent://'.length + 40 + 1, 'Bittorrent URL is expected length')
+
+    const listResponse = await fetch(createdURL)
+    t.ok(listResponse.ok, 'able to list directory')
+    const files = await listResponse.json()
+    const expectedFiles = ['example.txt', 'example2.txt', 'example.md'].sort()
+    t.deepEqual(files.sort(), expectedFiles.sort(), 'Got listing of uploaded files')
+  } finally {
+    await fetch.destroy()
+  }
+})
+
+test('Create a torrent using FormData to petname', async (t) => {
+  const fetch = makeBTFetch({
+    folder
+  })
+
+  try {
+    const form = new FormData()
+
+    form.append('name', 'TestTorrent')
+    form.append('file2', TEST_DATA, {
+      filename: 'example.txt'
+    })
+    form.append('file', TEST_DATA, {
+      filename: 'example2.txt'
+    })
+    // TODO: Figure out subfolders, might only work for mutable torrents?
+    form.append('file', TEST_DATA, {
+      filename: 'foldler/example.md'
+    })
+
+    const body = form.getBuffer()
+    const headers = form.getHeaders()
+
+    const response = await fetch('bittorrent://example/', {
+      method: 'POST',
+      headers,
+      body
+    })
+
+    // Resolve public key from response headers
+
+    t.ok(response.ok, 'Successful response')
+    const createdURL = await response.text()
+    t.equal(createdURL.length, 'bittorrent://'.length + 64 + 1, 'Bittorrent URL is expected length')
+    t.ok(createdURL.startsWith('bittorrent://'), 'got new bittorrent URL back')
+
+    const listResponse = await fetch(createdURL)
+    t.ok(listResponse.ok, 'able to list directory')
+    const files = await listResponse.json()
+    const expectedFiles = ['example.txt', 'example2.txt', 'example.md'].sort()
+    t.deepEqual(files.sort(), expectedFiles.sort(), 'Got listing of uploaded files')
+  } finally {
+    await fetch.destroy()
+  }
+})
+
+test('Test loading a well-seeded file', async (t) => {
+  const fetch = makeBTFetch({
+    folder
+  })
+
+  // InfoHash for the Sintel torrent
+  // Taken from https://webtorrent.io/docs
+  const url = 'bittorrent://08ada5a7a6183aae1e09d831df6748d566095a10/'
+  try {
+    const res = await fetch(url)
+
+    t.ok(res.ok, 'Response successful')
+    t.equal(res.status, 200, '200 OK')
+
+    const files = await res.json()
+
+    console.log(files)
+
+    const resHTML = await fetch(url, {
+      headers: {
+        Accept: 'text/html'
+      }
+    })
+
+    console.log('As HTML', await resHTML.text())
+
+    const srtURL = url + 'Sintel.en.srt'
+
+    console.log('Fetching subtitle track metadata')
+    console.log(srtURL)
+
+    const resHead = await fetch(srtURL, { method: 'head' })
+
+    const { headers, status } = resHead
+
+    console.log({
+      headers: [...headers],
+      status
+    })
+
+    console.log('Getting contents of srt file')
+
+    const resSRT = await fetch(srtURL)
+
+    for await (const chunk of resSRT.body) {
+      console.log('Chunk:', chunk)
+    }
+  } finally {
+    await fetch.destroy()
+  }
+})

--- a/torrent-manager.js
+++ b/torrent-manager.js
@@ -214,13 +214,13 @@ class TorrentManager {
     let getHostname = null
     if(this.inProgressLoad.has(hostname)){
       getHostname = this.inProgressLoad.get(hostname)
-      this.inProgressLoad.delete(hostname)
+      // this.inProgressLoad.delete(hostname)
     } else if(this.byPublicKey.has(hostname)) {
       getHostname = this.byPublicKey.get(hostname)
-      this.byPublicKey.delete(hostname)
+      // this.byPublicKey.delete(hostname)
     } else if(this.byInfohash.has(hostname)){
       getHostname = this.byInfohash.get(hostname)
-      this.byInfohash.delete(hostname)
+      // this.byInfohash.delete(hostname)
     }
     return new Promise((resolve, reject) => {
       getHostname.destroy({destroyStore: true}, error => {

--- a/torrent-manager.js
+++ b/torrent-manager.js
@@ -113,12 +113,16 @@ class TorrentManager {
     const isInfohash = hostname.length === 40 && HASH_REGEX.test(hostname)
     const isPublicKey = hostname.length === 64 && ADDRESS_REGEX.test(hostname)
     if (isInfohash) {
-      if (this.byInfohash.has(hostname)) return this.byInfohash.get(hostname)
+      if (this.byInfohash.has(hostname)) {
+        return this.byInfohash.get(hostname)
+      }
       return this.loadFromInfoHash(hostname)
     } else if (isPublicKey) {
-      if (this.byPublicKey.has(hostname)) return this.byPublicKey.get(hostname)
+      if (this.byPublicKey.has(hostname)) {
+        return this.byPublicKey.get(hostname)
+      }
       return this.loadFromPublicKey(hostname)
-    }
+    } else throw new Error('Unknown hostname type')
   }
 
   async loadFromInfoHash (infoHash) {

--- a/torrent-manager.js
+++ b/torrent-manager.js
@@ -1,16 +1,20 @@
 const WebTorrent = require('webtorrent')
 const fs = require('fs-extra')
 const path = require('path')
-const crypto = require('crypto')
 const sha1 = require('simple-sha1')
 const ed = require('ed25519-supercop')
+const derive = require('derive-key')
 const bencode = require('bencode')
 const busboy = require('busboy')
 const { Readable } = require('stream')
+const tmp = require('tmp-promise')
+const crypto = require('crypto')
+
 // const {EventIterator} = require('event-iterator')
 // const EventEmitter = require('events').EventEmitter
 
 const BTPK_PREFIX = 'urn:btpk:'
+const DERIVE_NAMESPACE = 'bittorrent://'
 
 // saves us from saving secret keys(saving secret keys even encrypted secret keys is something i want to avoid)
 // with this function which was taken from the bittorrent-dht package
@@ -22,205 +26,489 @@ function encodeSigData (msg) {
 }
 
 // setting up constants
-const checkHash = new RegExp('^[a-fA-F0-9]{40}$')
-const checkAddress = new RegExp('^[a-fA-F0-9]{64}$')
-const defOpts = { folder: __dirname, storage: 'storage', author: 'author', external: 'external', internal: 'internal', timeout: 60000, share: false, current: true, initial: true }
+const HASH_REGEX = /^[a-fA-F0-9]{40}$/
+const ADDRESS_REGEX = /^[a-fA-F0-9]{64}$/
 
-class Main {
+const defOpts = {
+  folder: __dirname,
+  timeout: 60000
+}
+
+class TorrentManager {
   constructor (opts = {}) {
     const finalOpts = { ...defOpts, ...opts }
-    this._current = finalOpts.current
-    this._share = finalOpts.share
-    this._timeout = finalOpts.timeout
-    this._initial = finalOpts.initial
+    this.timeout = finalOpts.timeout
 
-    finalOpts.folder = path.resolve(finalOpts.folder)
-    fs.ensureDirSync(finalOpts.folder)
+    this.folder = path.resolve(finalOpts.folder)
+    this.dataFolder = path.join(this.folder, 'data')
+    this.metadataFolder = path.join(this.folder, 'metadata')
+    this.seedKeyFile = path.join(this.folder, 'seed.key')
 
-    this._folder = finalOpts.folder
-    this._storage = this._folder + path.sep + finalOpts.storage
-    this._external = this._storage + path.sep + finalOpts.external
-    this._internal = this._storage + path.sep + finalOpts.internal
-    this._author = this._folder + path.sep + finalOpts.author
-    if (!fs.pathExistsSync(this._storage)) {
-      fs.ensureDirSync(this._storage)
+    fs.ensureDirSync(this.folder)
+    fs.ensureDirSync(this.dataFolder)
+    fs.ensureDirSync(this.metadataFolder)
+
+    if (fs.existsSync(this.seedKeyFile)) {
+      this.seedKey = fs.readFileSync(this.seedKeyFile)
+    } else {
+      this.seedKey = crypto.randomBytes(32)
+      fs.writeFileSync(this.seedKeyFile, this.seedKey)
     }
-    if (!fs.pathExistsSync(this._external)) {
-      fs.ensureDirSync(this._external)
-    }
-    if (!fs.pathExistsSync(this._internal)) {
-      fs.ensureDirSync(this._internal)
-    }
-    if (!fs.pathExistsSync(this._author)) {
-      fs.ensureDirSync(this._author)
-    }
+
+    this.inProgressLoad = new Map()
+    this.byInfohash = new Map()
+    this.byPublicKey = new Map()
+
     this.webtorrent = new WebTorrent({ dht: { verify: ed.verify } })
-    this.webtorrent.on('error', error => {
-      console.error(error)
-    })
     this._readyToGo = true
 
-    // run the start up function
-    this.startUp().catch(error => { console.error(error) })
-
     // run the keepUpdated function every 1 hour, it keep the data active by putting the data back into the dht, don't run it if it is still working from the last time it ran the keepUpdated function
-    this.updateRoutine = setInterval(() => {
-      if (this._readyToGo) {
-        this.keepUpdated().catch(error => { console.error(error) })
-      }
-    }, 3600000)
+    // this.updateRoutine = setInterval(() => {
+    //  if (this._readyToGo) {
+    //    this.keepUpdated().catch(error => { console.error(error) })
+    //  }
+    // }, 3600000)
   }
 
-// keep data active in the dht, runs every hour
-async keepUpdated () {
-  this._readyToGo = false
-  for (const torrent of this.webtorrent.torrents) {
-    if (torrent.address) {
-      try {
-        await this.bothGetPut(torrent)
-      } catch (error) {
-        console.error(error)
-      }
-      await new Promise((resolve, reject) => setTimeout(resolve, 5000))
+  _trackTorrent (torrent) {
+    const { infoHash, publicKey, name, files, path: torrentPath } = torrent
+    const parentPath = path.join(torrentPath, name)
+
+    files.forEach((file) => {
+      file.relativePath = file.path.slice(parentPath.length).replace(/\\/, '/')
+    })
+
+    const infoHashURL = infoHash.toString('hex')
+    if (this.byInfohash.has(infoHashURL)) throw new Error('Already tracking ' + infoHashURL)
+    this.byInfohash.set(infoHashURL, torrent)
+    torrent.on('close', () => {
+      this.byInfohash.delete(infoHashURL)
+    })
+
+    if (!publicKey) return
+    const publicKeyURL = publicKey.toString('hex')
+    if (this.byInfohash.has(publicKeyURL)) throw new Error('Already tracking ' + publicKeyURL)
+    this.byPublicKey.set(publicKeyURL, torrent)
+    torrent.on('close', () => {
+      this.byPublicKey.delete(publicKeyURL)
+    })
+  }
+
+  async resolveTorrent (hostname) {
+    if (this.inProgressLoad.has(hostname)) {
+      return this.inProgressLoad.get(hostname)
     }
-  }
-  this._readyToGo = true
-}
+    const loader = this._resolveTorrent(hostname)
+    this.inProgressLoad.set(hostname, loader)
 
-// -------------------------------------
-// start up functions runs on every start up
-// -------------------------------------------
-async startUp () {
-  // a mechanism to clear all data meaning delete all user-created torrents, all non-user created torrents, and all BEP46 publishing data, most likely too extreme and not needed
+    try {
+      const torrent = await loader
 
-  // if(this._clear){
-    // await fs.emptyDir(this._external)
-    // await fs.emptyDir(this._internal)
-    // await fs.emptyDir(this._author)
-  // }
-
-  // if initial option is true, then start seeding all user created torrents on start up
-  if (this._initial) {
-    const checkInternal = await fs.readdir(this._internal, { withFileTypes: false })
-    for (const checkInternalPath of checkInternal) {
-      try {
-        const folderPath = path.join(this._internal, checkInternalPath)
-        if (checkAddress.test(checkInternalPath)) {
-          const checkTorrent = await Promise.race([
-            this.delayTimeOut(this._timeout, new Error('torrent took too long'), false),
-            new Promise((resolve, reject) => {
-              this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
-                resolve(torrent)
-              })
-            })
-          ])
-          checkTorrent.folder = folderPath
-          const checkProperty = await Promise.race([
-            this.delayTimeOut(this._timeout, new Error('property took too long'), false),
-            this.ownData(checkInternalPath, checkTorrent.infoHash)
-          ]).catch(error => {
-            this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
-            throw error
-          })
-          // don't overwrite the torrent's infohash even though they will both be the same
-          delete checkProperty.infoHash
-          for (const prop in checkProperty) {
-            checkTorrent[prop] = checkProperty[prop]
-          }
-          checkTorrent.folder = folderPath
-          console.log(checkInternalPath + ' is good')
-        } else if (checkHash.test(checkInternalPath)) {
-          const checkTorrent = await Promise.race([
-            this.delayTimeOut(this._timeout, new Error('torrent took too long'), false),
-            new Promise((resolve, reject) => {
-              this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
-                resolve(torrent)
-              })
-            })
-          ])
-          checkTorrent.folder = folderPath
-          checkTorrent.hash = checkInternalPath
-          console.log(checkInternalPath + ' is good')
-        } else {
-          await fs.remove(folderPath)
-        }
-      } catch (error) {
-        console.error(error)
-      }
+      return torrent
+    } finally {
+      this.inProgressLoad.delete(hostname)
     }
   }
 
-  // if share option is true, then start seeding(webtorrent.add seeds after torrent is downloaded) on start up
-  if (this._share) {
-    const checkExternal = await fs.readdir(this._external, { withFileTypes: false })
-    for (const checkExternalPath of checkExternal) {
-      try {
-        const folderPath = path.join(this._external, checkExternalPath)
-        if (checkAddress.test(checkExternalPath)) {
-          const checkProperty = await Promise.race([
-            this.delayTimeOut(this._timeout, new Error('property took too long'), false),
-            this.resolve(checkExternalPath)
-          ])
-          if (this._current) {
-            if (!await fs.pathExists(path.join(folderPath, checkProperty.infoHash))) {
-              await fs.emptyDir(folderPath)
+  async _resolveTorrent (hostname) {
+    const isInfohash = hostname.length === 40 && HASH_REGEX.test(hostname)
+    const isPublicKey = hostname.length === 64 && ADDRESS_REGEX.test(hostname)
+    if (isInfohash) {
+      if (this.byInfohash.has(hostname)) return this.byInfohash.get(hostname)
+      return this.loadFromInfoHash(hostname)
+    } else if (isPublicKey) {
+      if (this.byPublicKey.has(hostname)) return this.byPublicKey.get(hostname)
+      return this.loadFromPublicKey(hostname)
+    }
+  }
+
+  async loadFromInfoHash (infoHash) {
+    const torrentFile = await this.loadTorrentFile(infoHash)
+
+    const torrentId = torrentFile || {
+      infoHash,
+      so: '-1'
+    }
+
+    const folderPath = path.join(this.dataFolder, infoHash)
+    const torrent = await this.loadTorrent(torrentId, folderPath)
+
+    this._trackTorrent(torrent)
+
+    return torrent
+  }
+
+  async loadFromPublicKey (publicKey) {
+    const folderPath = path.join(this.dataFolder, publicKey)
+    const existingRecord = await this.loadRecord(publicKey)
+    // Load latest from DHT, and load the torrent
+    try {
+      console.log('Resolving public key')
+      let { infoHash, record, sequence } = await this.resolvePublicKey(publicKey)
+
+      let torrentFile = null
+      if (existingRecord && existingRecord?.seq >= sequence) {
+        console.log('Loading existing torrent data')
+        infoHash = existingRecord.v.ih.toString('hex')
+        torrentFile = await this.loadTorrentFile(publicKey)
+        record = existingRecord
+      } else {
+        await this.saveRecord(publicKey, record)
+      }
+
+      const torrentId = torrentFile || {
+        infoHash,
+        so: '-1'
+      }
+
+      console.log('Loading torrent')
+      const torrent = await this.loadTorrent(torrentId, folderPath)
+
+      torrent.publicKey = publicKey
+      this._trackTorrent(torrent)
+      await this.saveTorrentFile(torrent)
+      return torrent
+    } catch (e) {
+      // TODO: Other messages that mean we could not resolve the address?
+      if (!e.message.includes('Could not resolve address')) throw e
+      console.error(e.stack)
+
+      // If it fails, try loading record from cache
+      // Use saved torrent file (underpublickey) to load the torrent
+      // TODO: Check error type?
+      if (!existingRecord) throw new Error('Could not resolve torrent')
+
+      const torrentFile = await this.loadTorrentFile(publicKey)
+
+      const torrent = await this.loadTorrent(torrentFile, folderPath)
+      torrent.record = existingRecord
+      torrent.publicKey = publicKey
+
+      this._trackTorrent(torrent)
+
+      return torrent
+    }
+  }
+
+  async loadTorrent (torrentId, folderPath) {
+    await fs.ensureDir(folderPath)
+
+    const options = {
+      path: folderPath,
+      addUID: false
+    }
+
+    const torrent = await Promise.race([
+      delayTimeout(this.timeout, new Error('Timeout: torrent took too long to load')),
+      new Promise((resolve, reject) => {
+        this.webtorrent.add(torrentId, options, torrent => {
+          resolve(torrent)
+        })
+      })
+    ])
+
+    return torrent
+  }
+
+  async publishPublicKey (publicKey, secretKey, headers, data, name = 'bt-fetch torrent') {
+    if (this.byPublicKey.has(publicKey)) {
+      console.log('Stopping existing torrent')
+      await new Promise((resolve, reject) => {
+        this.byPublicKey.get(publicKey).destroy((err) => {
+          if (err) reject(err)
+          else resolve()
+        })
+      })
+    }
+    const folderPath = path.join(this.dataFolder, publicKey, name)
+    await fs.ensureDir(folderPath)
+
+    console.log('Saving torrent data to folder')
+    const {
+      comment,
+      createdBy = 'bt-fetch',
+      creationDate
+    } = await this.handleFormData(folderPath, headers, data)
+
+    // TODO: Support "info" field?
+    const finalOpts = {
+      name,
+      comment,
+      createdBy,
+      creationDate,
+      addUID: false
+    }
+
+    console.log('Converting folder to torrent')
+    const tmpTorrent = await new Promise((resolve, reject) => {
+      this.webtorrent.seed(folderPath, finalOpts, torrent => {
+        resolve(torrent)
+      })
+    })
+
+    tmpTorrent.publicKey = publicKey
+
+    const { infoHash } = tmpTorrent
+
+    await this.saveTorrentFile(tmpTorrent)
+
+    await new Promise((resolve, reject) => {
+      tmpTorrent.destroy((err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+
+    // Try to resolve existing sequence?
+    let sequence = 0
+    try {
+      console.log('Detecting existing sequence number')
+      const record = await this.dhtGet(publicKey)
+      if (record?.seq) {
+        sequence = record?.seq
+      }
+    } catch (e) {
+      // Whatever?
+      console.log('Existing sequence not found')
+      console.error(e)
+    }
+
+    // Generate record and publish
+    console.log('Publishing to DHT')
+    await this.dhtPublish(publicKey, secretKey, infoHash, sequence)
+
+    console.log('Loading from public key')
+    return this.loadFromPublicKey(publicKey)
+  }
+
+  async publishHash (headers, data, title = 'bt-fetch torrent') {
+    const { path: tmpPath, cleanup } = await tmp.dir({ unsafeCleanup: true })
+    try {
+      await fs.ensureDir(tmpPath)
+
+      const {
+        name = title,
+        comment,
+        createdBy = 'bt-fetch',
+        creationDate
+      } = await this.handleFormData(tmpPath, headers, data)
+
+      // TODO: Support "info" field?
+      const finalOpts = {
+        name,
+        comment,
+        createdBy,
+        creationDate,
+        addUID: false
+      }
+
+      const tmpTorrent = await new Promise((resolve, reject) => {
+        this.webtorrent.seed(tmpPath, finalOpts, torrent => {
+          resolve(torrent)
+        })
+      })
+
+      const { infoHash } = tmpTorrent
+
+      await this.saveTorrentFile(tmpTorrent)
+
+      await new Promise((resolve, reject) => {
+        tmpTorrent.destroy((err) => {
+          if (err) reject(err)
+          else resolve()
+        })
+      })
+
+      const folderPath = path.join(this.dataFolder, infoHash, name)
+      await fs.move(tmpPath, folderPath)
+
+      return this.loadFromInfoHash(infoHash)
+    } finally {
+      cleanup()
+    }
+  }
+
+  async dhtGet (publicKey) {
+    try {
+      const record = await new Promise((resolve, reject) => {
+        sha1(publicKey, (targetID) => {
+          this.webtorrent.dht.get(targetID, (err, res) => {
+            if (err) {
+              reject(err)
+            } else if (res) {
+              resolve(res)
+            } else if (!res) {
+              reject(new Error('Could not resolve address'))
             }
-          } else if (!this._current) {
-            await fs.ensureDir(folderPath)
-          }
-          const checkTorrent = await Promise.race([
-            this.delayTimeOut(this._timeout, new Error('torrent took too long'), false),
-            new Promise((resolve, reject) => {
-              this.webtorrent.add(checkProperty.infoHash, { path: folderPath + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true }, torrent => {
-                resolve(torrent)
-              })
-            })
-          ])
-          checkTorrent.folder = folderPath
-          // don't overwrite the torrent's infohash even though they will both be the same
-          delete checkProperty.infoHash
-          for (const prop in checkProperty) {
-            checkTorrent[prop] = checkProperty[prop]
-          }
-          console.log(checkExternalPath + ' is good')
-        } else if (checkHash.test(checkExternalPath)) {
-          const checkTorrent = await Promise.race([
-            this.delayTimeOut(this._timeout, new Error('torrent took too long'), false),
-            new Promise((resolve, reject) => {
-              this.webtorrent.add(checkExternalPath, { path: folderPath, destroyStoreOnDestroy: true }, torrent => {
-                resolve(torrent)
-              })
-            })
-          ])
-          checkTorrent.folder = folderPath
-          checkTorrent.hash = checkExternalPath
-          console.log(checkExternalPath + ' is good')
-        } else {
-          await fs.remove(folderPath)
-        }
-      } catch (error) {
-        console.error(error)
-      }
+          })
+        })
+      })
+      return record
+    } catch (e) {
+      console.error('Could not load DHT record', e.stack)
+      const record = await this.loadRecord(publicKey)
+      if (record) return record
+      throw e
     }
   }
-}
 
-delayTimeOut(timeout, data, res = false){
-  return new Promise((resolve, reject) => {setTimeout(() => {if(res){resolve(data)} else {reject(data)}}, timeout)})
-  // if(res){
-  //   return new Promise((resolve, reject) => {
-  //     setTimeout(() => {
-  //       resolve(data)
-  //     }, timeout)
-  //   })
-  // } else {
-  //   return new Promise((resolve, reject) => {
-  //     setTimeout(() => {
-  //       reject(data)
-  //     }, timeout)
-  //   })
-  // }
-}
+  async dhtPut (data) {
+    return new Promise((resolve, reject) => {
+      this.webtorrent.dht.put(data, (err, hash) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(hash.toString('hex'))
+        }
+      })
+    })
+  }
+
+  async dhtPublish (publicKey, secretKey, infoHash, seq = 0) {
+    const publicKeyBuff = Buffer.from(publicKey, 'hex')
+    const secretKeyBuff = Buffer.from(secretKey, 'hex')
+    const ih = Buffer.from(infoHash, 'hex')
+
+    const v = { ih }
+    const toSign = encodeSigData({ seq, v })
+
+    const sig = ed.sign(toSign, publicKeyBuff, secretKeyBuff)
+    const record = { k: publicKeyBuff, v, seq, sig }
+
+    await this.saveRecord(publicKey, record)
+
+    return this.dhtPut(record)
+  }
+
+  async loadRecord (publicKey) {
+    const fileLocation = path.join(this.folder, 'metadata', `${publicKey}.dht_record`)
+    const exists = await fs.pathExists(fileLocation)
+    if (!exists) return null
+    const buffer = await fs.readFile(fileLocation)
+    return bencode.decode(buffer)
+  }
+
+  async saveRecord (publicKey, record) {
+    const fileLocation = path.join(this.folder, 'metadata', `${publicKey}.dht_record`)
+    const buffer = bencode.encode(record)
+    await fs.writeFile(fileLocation, buffer)
+  }
+
+  async saveTorrentFile (torrent) {
+    const { publicKey, infoHash, torrentFile } = torrent
+    const hostname = publicKey || infoHash
+    const fileLocation = path.join(this.folder, 'metadata', `${hostname}.torrent`)
+    await fs.writeFile(fileLocation, torrentFile)
+  }
+
+  async loadTorrentFile (hostname) {
+    const fileLocation = path.join(this.folder, 'metadata', `${hostname}.torrent`)
+
+    const exists = await fs.pathExists(fileLocation)
+    if (!exists) return null
+    return fs.readFile(fileLocation)
+  }
+
+  // resolve public key address to an infohash
+  async resolvePublicKey (publicKey) {
+    const record = await this.dhtGet(publicKey)
+
+    const { seq, v } = record
+    const { ih } = v
+
+    const infoHash = ih.toString('hex')
+    const sequence = seq
+
+    console.log({ record, infoHash })
+
+    if (!HASH_REGEX.test(infoHash)) throw new Error('Resolved public key infoHash invalid')
+    if (!Number.isInteger(sequence)) throw new Error('Resolved public key sequence number invalid')
+
+    return {
+      infoHash,
+      sequence,
+      record
+    }
+  }
+
+  handleFormData (folderPath, headers, data) {
+    const bb = busboy({ headers })
+    const additionalInfo = {}
+
+    return new Promise((resolve, reject) => {
+      function handleRemoval () {
+        bb.off('file', handleFiles)
+        bb.off('error', handleErrors)
+        bb.off('finish', handleFinish)
+      }
+      function handleFiles (name, file, info) {
+        const { filename } = info
+        const finalLocation = path.join(folderPath, filename)
+        const writeStream = fs.createWriteStream(finalLocation)
+        Readable.from(file).pipe(writeStream)
+      }
+      function handleErrors (error) {
+        handleRemoval()
+        reject(error)
+      }
+      function handleFinish () {
+        handleRemoval()
+        resolve(additionalInfo)
+      }
+      function handleField (name, val) {
+        additionalInfo[name] = val
+      }
+      bb.on('file', handleFiles)
+      bb.on('field', handleField)
+      bb.once('error', handleErrors)
+      bb.once('close', handleFinish)
+      Readable.from(data).pipe(bb)
+    })
+  }
+
+  // create a keypair
+  createKeypair (petname = null) {
+    let seed = null
+    if (petname) {
+      seed = derive(DERIVE_NAMESPACE, this.seedKey, petname)
+    } else {
+      seed = ed.createSeed()
+    }
+
+    const {
+      publicKey,
+      secretKey
+    } = ed.createKeyPair(seed)
+
+    return {
+      publicKey: publicKey.toString('hex'),
+      secretKey: secretKey.toString('hex')
+    }
+  }
+
+  /*
+
+OLD STUFF
+
+TODO: Clear unneeded bits
+========================================================
+  */
+
+  // keep data active in the dht, runs every hour
+  async keepUpdated () {
+    this._readyToGo = false
+    for (const torrent of this.webtorrent.torrents) {
+      if (torrent.address) {
+        try {
+          await this.bothGetPut(torrent)
+        } catch (error) {
+          console.error(error)
+        }
+        await new Promise((resolve, reject) => setTimeout(resolve, 5000))
+      }
+    }
+    this._readyToGo = true
+  }
 
   // when we resume or seed a user created BEP46 torrent that has already been created before
   // we have to check that the infohash of the torrent(remember we do not know the infohash before) matches the signature
@@ -263,7 +551,7 @@ delayTimeOut(timeout, data, res = false){
         })
       })
     })
-    if (!checkHash.test(getData.v.ih.toString('utf-8')) || !Number.isInteger(getData.seq)) {
+    if (!HASH_REGEX.test(getData.v.ih.toString('utf-8')) || !Number.isInteger(getData.seq)) {
       throw new Error('data is invalid')
     }
     for (const prop in getData.v) {
@@ -280,7 +568,7 @@ delayTimeOut(timeout, data, res = false){
         throw new Error('text data must be strings')
       }
     }
-    if (!checkHash.test(text.ih)) {
+    if (!HASH_REGEX.test(text.ih)) {
       throw new Error('must have infohash')
     }
     if (!address || !secret) {
@@ -295,7 +583,7 @@ delayTimeOut(timeout, data, res = false){
     let seq = null
     if (await fs.pathExists(this._author + path.sep + address)) {
       main = await fs.readFile(this._author + path.sep + address)
-      main = JSON.parse(data.toString())
+      main = JSON.parse(main.toString())
       seq = main.sequence + 1
     } else {
       seq = 0
@@ -338,7 +626,7 @@ delayTimeOut(timeout, data, res = false){
       throw new Error('folder does not exist')
     }
     const checkTorrent = await Promise.race([
-      this.delayTimeOut(this._timeout, new Error(hash + ' took too long, it timed out'), false),
+      delayTimeout(this.timeout, new Error(hash + ' took too long, it timed out'), false),
       new Promise((resolve, reject) => {
         this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
           resolve(torrent)
@@ -361,7 +649,7 @@ delayTimeOut(timeout, data, res = false){
       throw new Error('folder does not exist')
     }
     const checkTorrent = await Promise.race([
-      this.delayTimeOut(this._timeout, new Error(address + ' took too long, it timed out'), false),
+      delayTimeout(this.timeout, new Error(address + ' took too long, it timed out'), false),
       new Promise((resolve, reject) => {
         this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
           resolve(torrent)
@@ -369,7 +657,7 @@ delayTimeOut(timeout, data, res = false){
       })
     ])
     const checkProperty = await Promise.race([
-      this.delayTimeOut(this._timeout, new Error(address + ' property took too long, it timed out, please try again with only the keypair without the folder'), false),
+      delayTimeout(this.timeout, new Error(address + ' property took too long, it timed out, please try again with only the keypair without the folder'), false),
       this.ownData(address, checkTorrent.infoHash)
     ]).catch(error => {
       this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
@@ -384,65 +672,6 @@ delayTimeOut(timeout, data, res = false){
     return checkTorrent
   }
 
-  // download a regular non-BEP46 non-user created torrent by entering a 40 character infohash
-  async loadHash (hash) {
-    const haveTorrent = this.findTheHash(hash)
-    if (haveTorrent) {
-      return haveTorrent
-    }
-    // if user had torrent before, then empty the folder so previous data does not conflict with the infohash
-    const folderPath = path.join(this._external, hash)
-    const checkTorrent = await Promise.race([
-      this.delayTimeOut(this._timeout, new Error(hash + ' took too long, it timed out'), false),
-      new Promise((resolve, reject) => {
-        this.webtorrent.add(hash, { path: folderPath, destroyStoreOnDestroy: true }, torrent => {
-          resolve(torrent)
-        })
-      })
-    ])
-    checkTorrent.folder = folderPath
-    checkTorrent.hash = checkTorrent.infoHash
-    return checkTorrent
-  }
-
-  // publish a regular non-BEP46 torrent, we need a path to the directory where the data is
-  // we copy it to a new sub-directory(inside the this._internal directory)
-  // that will have a 32 character md5 hash as it's sub-directory name
-  // we do this because we can not name it with the infohash
-  // because we do not know the infohash of this torrent beforehand
-  // we return the torrent along with the title
-  // that way the user knows the title when they want to start the torrent
-  async publishHash (hash, headers, data) {
-    if(hash){
-      this.stopHash(hash)
-    } else {
-      hash = crypto.randomBytes(20).toString('hex')
-    }
-    const folderPath = path.join(this._internal, hash)
-    await fs.ensureDir(folderPath)
-    // await Promise.race([
-    //   this.delayTimeOut(this._timeout, new Error('took too long to write to disk'), false),
-    //   this.handleFormData(folderPath, headers, data)
-    // ])
-    await this.handleFormData(folderPath, headers, data)
-    const checkFolderPath = await fs.readdir(folderPath, {withFileTypes: false})
-    if(!checkFolderPath.length){
-      await fs.remove(folderPath)
-      throw new Error('data could not be written to new torrent')
-    }
-    const checkTorrent = await Promise.race([
-      this.delayTimeOut(this._timeout, new Error('torrent took too long, it timed out'), false),
-      new Promise((resolve, reject) => {
-        this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
-          resolve(torrent)
-        })
-      })
-    ])
-    checkTorrent.folder = folderPath
-    checkTorrent.hash = hash
-    return { torrent: checkTorrent, hash: checkTorrent.hash }
-  }
-
   // download a non-user created BEP46 torrent by their public key address, non-user meaning someone else's BEP46 torrent
   async loadAddress (address) {
     const haveTorrent = this.findTheAddress(address)
@@ -450,7 +679,7 @@ delayTimeOut(timeout, data, res = false){
       return haveTorrent
     }
     const checkProperty = await Promise.race([
-      this.delayTimeOut(this._timeout, new Error(address + ' property took too long, it timed out'), false),
+      delayTimeout(this.timeout, new Error(address + ' property took too long, it timed out'), false),
       this.resolveFunc(address)
     ])
 
@@ -469,7 +698,7 @@ delayTimeOut(timeout, data, res = false){
     }
 
     const checkTorrent = await Promise.race([
-      this.delayTimeOut(this._timeout, new Error(checkProperty.address + ' took too long, it timed out'), false),
+      delayTimeout(this.timeout, new Error(checkProperty.address + ' took too long, it timed out'), false),
       new Promise((resolve, reject) => {
         this.webtorrent.add(checkProperty.infoHash, { path: checkProperty.folder + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true }, torrent => {
           resolve(torrent)
@@ -497,18 +726,14 @@ delayTimeOut(timeout, data, res = false){
     }
     const folderPath = path.join(this._internal, keypair.address)
     await fs.ensureDir(folderPath)
-    // await Promise.race([
-    //   this.delayTimeOut(this._timeout, new Error('took too long to write to disk'), false),
-    //   this.handleFormData(folderPath, headers, data)
-    // ])
     await this.handleFormData(folderPath, headers, data)
-    const checkFolderPath = await fs.readdir(folderPath, {withFileTypes: false})
-    if(!checkFolderPath.length){
+    const checkFolderPath = await fs.readdir(folderPath, { withFileTypes: false })
+    if (!checkFolderPath.length) {
       await fs.remove(folderPath)
       throw new Error('data could not be written to new torrent')
     }
     const checkTorrent = await Promise.race([
-      this.delayTimeOut(this._timeout, new Error('torrent took too long, it timed out'), false),
+      delayTimeout(this.timeout, new Error('torrent took too long, it timed out'), false),
       new Promise((resolve, reject) => {
         this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
           resolve(torrent)
@@ -516,7 +741,7 @@ delayTimeOut(timeout, data, res = false){
       })
     ])
     const checkProperty = await Promise.race([
-      this.delayTimeOut(this._timeout, new Error(keypair.address + ' property took too long, it timed out, please try again with only the keypair without the folder'), false),
+      delayTimeout(this.timeout, new Error(keypair.address + ' property took too long, it timed out, please try again with only the keypair without the folder'), false),
       this.publishFunc(keypair.address, keypair.secret, { ih: checkTorrent.infoHash })
     ]).catch(error => {
       this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
@@ -602,13 +827,13 @@ delayTimeOut(timeout, data, res = false){
   // stop the torrent with the infohash, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
   async removeHash (hash) {
     const checkTorrent = this.findTheHash(hash)
-    if(!checkTorrent){
+    if (!checkTorrent) {
       throw new Error('could not find ' + hash)
     }
     const folder = checkTorrent.folder
     this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
     if (folder) {
-      if(await fs.pathExists(folder)){
+      if (await fs.pathExists(folder)) {
         await fs.remove(folder)
       }
     } else {
@@ -625,13 +850,13 @@ delayTimeOut(timeout, data, res = false){
   // stop the torrent with the address, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
   async removeAddress (address) {
     const checkedTorrent = this.findTheAddress(address)
-    if(!checkedTorrent){
+    if (!checkedTorrent) {
       throw new Error('could not find ' + address)
     }
     const folder = checkedTorrent.folder
     this.webtorrent.remove(checkedTorrent.infoHash, { destroyStore: false })
     if (folder) {
-      if(await fs.pathExists(folder)){
+      if (await fs.pathExists(folder)) {
         await fs.remove(folder)
       }
     } else {
@@ -681,35 +906,6 @@ delayTimeOut(timeout, data, res = false){
       }
     }
     return tempTorrent
-  }
-
-  handleFormData(folderPath, headers, data){
-    const bb = busboy({ headers })
-    
-    return new Promise((resolve, reject) => {
-      function handleRemoval(){
-        bb.off('file', handleFiles)
-        bb.off('error', handleErrors)
-        bb.off('finish', handleFinish)
-      }
-      function handleFiles(name, file, info){
-        // fs.writeFile(path.join(folderPath, info.filename), Readable.from(file))
-        // const saveTo = fs.createWriteStream(path.join(folderPath, info.filename))
-        Readable.from(file).pipe(fs.createWriteStream(path.join(folderPath, info.filename)))
-      }
-      function handleErrors(error){
-        handleRemoval()
-        reject(error)
-      }
-      function handleFinish(){
-        handleRemoval()
-        resolve(null)
-      }
-      bb.on('file', handleFiles)
-      bb.on('error', handleErrors)
-      bb.on('finish', handleFinish)
-      Readable.from(data).pipe(bb)
-    })
   }
 
   // -------------- the below functions are BEP46 helpders, especially bothGetPut which keeps the data active in the dht ----------------
@@ -788,52 +984,18 @@ delayTimeOut(timeout, data, res = false){
       })
     })
   }
-
-  // create a keypair
-  createKeypair () {
-    const { publicKey, secretKey } = ed.createKeyPair(ed.createSeed())
-
-    return { address: publicKey.toString('hex'), secret: secretKey.toString('hex') }
-  }
-
-  // extract the public key/address out of a link
-  addressFromLink (link) {
-    if (!link || typeof (link) !== 'string') {
-      return ''
-    } else if (link.startsWith('bt')) {
-      try {
-        const parsed = new URL(link)
-
-        if (!parsed.hostname) {
-          return ''
-        } else {
-          return parsed.hostname
-        }
-      } catch (error) {
-        console.error(error)
-        return ''
-      }
-    } else if (link.startsWith('magnet')) {
-      try {
-        const parsed = new URL(link)
-
-        const xs = parsed.searchParams.get('xs')
-
-        const isMutableLink = xs && xs.startsWith(BTPK_PREFIX)
-
-        if (!isMutableLink) {
-          return ''
-        } else {
-          return xs.slice(BTPK_PREFIX.length)
-        }
-      } catch (error) {
-        console.error(error)
-        return ''
-      }
-    } else {
-      return ''
-    }
-  }
 }
 
-module.exports = Main
+function delayTimeout (timeout, data, shouldResolve = false) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (shouldResolve) {
+        resolve(data)
+      } else {
+        reject(data)
+      }
+    }, timeout)
+  })
+}
+
+module.exports = TorrentManager

--- a/torrent-manager.js
+++ b/torrent-manager.js
@@ -210,6 +210,29 @@ class TorrentManager {
     return torrent
   }
 
+  deleteTorrent(hostname){
+    let getHostname = null
+    if(this.inProgressLoad.has(hostname)){
+      getHostname = this.inProgressLoad.get(hostname)
+      this.inProgressLoad.delete(hostname)
+    } else if(this.byPublicKey.has(hostname)) {
+      getHostname = this.byPublicKey.get(hostname)
+      this.byPublicKey.delete(hostname)
+    } else if(this.byInfohash.has(hostname)){
+      getHostname = this.byInfohash.get(hostname)
+      this.byInfohash.delete(hostname)
+    }
+    return new Promise((resolve, reject) => {
+      getHostname.destroy({destroyStore: true}, error => {
+        if(error){
+          reject(error)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
   async publishPublicKey (publicKey, secretKey, headers, data, name = 'bt-fetch torrent') {
     if (this.byPublicKey.has(publicKey)) {
       console.log('Stopping existing torrent')

--- a/torrent-manager.js
+++ b/torrent-manager.js
@@ -13,7 +13,6 @@ const crypto = require('crypto')
 // const {EventIterator} = require('event-iterator')
 // const EventEmitter = require('events').EventEmitter
 
-const BTPK_PREFIX = 'urn:btpk:'
 const DERIVE_NAMESPACE = 'bittorrent://'
 
 // saves us from saving secret keys(saving secret keys even encrypted secret keys is something i want to avoid)
@@ -143,12 +142,10 @@ class TorrentManager {
     const existingRecord = await this.loadRecord(publicKey)
     // Load latest from DHT, and load the torrent
     try {
-      console.log('Resolving public key')
       let { infoHash, record, sequence } = await this.resolvePublicKey(publicKey)
 
       let torrentFile = null
       if (existingRecord && existingRecord?.seq >= sequence) {
-        console.log('Loading existing torrent data')
         infoHash = existingRecord.v.ih.toString('hex')
         torrentFile = await this.loadTorrentFile(publicKey)
         record = existingRecord
@@ -161,7 +158,6 @@ class TorrentManager {
         so: '-1'
       }
 
-      console.log('Loading torrent')
       const torrent = await this.loadTorrent(torrentId, folderPath)
 
       torrent.publicKey = publicKey
@@ -210,21 +206,11 @@ class TorrentManager {
     return torrent
   }
 
-  deleteTorrent(hostname){
-    let getHostname = null
-    if(this.inProgressLoad.has(hostname)){
-      getHostname = this.inProgressLoad.get(hostname)
-      // this.inProgressLoad.delete(hostname)
-    } else if(this.byPublicKey.has(hostname)) {
-      getHostname = this.byPublicKey.get(hostname)
-      // this.byPublicKey.delete(hostname)
-    } else if(this.byInfohash.has(hostname)){
-      getHostname = this.byInfohash.get(hostname)
-      // this.byInfohash.delete(hostname)
-    }
+  async deleteTorrent (hostname) {
+    const torrent = await this.resolveTorrent(hostname)
     return new Promise((resolve, reject) => {
-      getHostname.destroy({destroyStore: true}, error => {
-        if(error){
+      torrent.destroy({ destroyStore: true }, error => {
+        if (error) {
           reject(error)
         } else {
           resolve()
@@ -233,25 +219,41 @@ class TorrentManager {
     })
   }
 
-  async publishPublicKey (publicKey, secretKey, headers, data, name = 'bt-fetch torrent') {
+  async publishPublicKey (publicKey, secretKey, headers, data, pathname = '/', name = 'bt-fetch torrent') {
     if (this.byPublicKey.has(publicKey)) {
-      console.log('Stopping existing torrent')
       await new Promise((resolve, reject) => {
         this.byPublicKey.get(publicKey).destroy((err) => {
           if (err) reject(err)
           else resolve()
         })
       })
+    } else {
+      // Try loading for the first time
+      try {
+        const torrent = await this.loadFromPublicKey(publicKey)
+
+        name = torrent.name
+
+        await new Promise((resolve, reject) => {
+          torrent.destroy((err) => {
+            if (err) reject(err)
+            else resolve()
+          })
+        })
+      } catch (e) {
+        // Whatever?
+        console.error(e.stack)
+      }
     }
     const folderPath = path.join(this.dataFolder, publicKey, name)
-    await fs.ensureDir(folderPath)
+    const savePath = path.join(folderPath, pathname)
+    await fs.ensureDir(savePath)
 
-    console.log('Saving torrent data to folder')
     const {
       comment,
       createdBy = 'bt-fetch',
       creationDate
-    } = await this.handleFormData(folderPath, headers, data)
+    } = await this.handleFormData(savePath, headers, data)
 
     // TODO: Support "info" field?
     const finalOpts = {
@@ -262,7 +264,6 @@ class TorrentManager {
       addUID: false
     }
 
-    console.log('Converting folder to torrent')
     const tmpTorrent = await new Promise((resolve, reject) => {
       this.webtorrent.seed(folderPath, finalOpts, torrent => {
         resolve(torrent)
@@ -285,36 +286,33 @@ class TorrentManager {
     // Try to resolve existing sequence?
     let sequence = 0
     try {
-      console.log('Detecting existing sequence number')
       const record = await this.dhtGet(publicKey)
       if (record?.seq) {
         sequence = record?.seq
       }
     } catch (e) {
       // Whatever?
-      console.log('Existing sequence not found')
       console.error(e)
     }
 
     // Generate record and publish
-    console.log('Publishing to DHT')
     await this.dhtPublish(publicKey, secretKey, infoHash, sequence)
 
-    console.log('Loading from public key')
     return this.loadFromPublicKey(publicKey)
   }
 
-  async publishHash (headers, data, title = 'bt-fetch torrent') {
+  async publishHash (headers, data, pathname = '/', title = 'bt-fetch torrent') {
     const { path: tmpPath, cleanup } = await tmp.dir({ unsafeCleanup: true })
     try {
       await fs.ensureDir(tmpPath)
+      const savePath = path.join(tmpPath, pathname)
 
       const {
         name = title,
         comment,
         createdBy = 'bt-fetch',
         creationDate
-      } = await this.handleFormData(tmpPath, headers, data)
+      } = await this.handleFormData(savePath, headers, data)
 
       // TODO: Support "info" field?
       const finalOpts = {
@@ -442,8 +440,6 @@ class TorrentManager {
     const infoHash = ih.toString('hex')
     const sequence = seq
 
-    console.log({ record, infoHash })
-
     if (!HASH_REGEX.test(infoHash)) throw new Error('Resolved public key infoHash invalid')
     if (!Number.isInteger(sequence)) throw new Error('Resolved public key sequence number invalid')
 
@@ -507,505 +503,6 @@ class TorrentManager {
       publicKey: publicKey.toString('hex'),
       secretKey: secretKey.toString('hex')
     }
-  }
-
-  /*
-
-OLD STUFF
-
-TODO: Clear unneeded bits
-========================================================
-  */
-
-  // keep data active in the dht, runs every hour
-  async keepUpdated () {
-    this._readyToGo = false
-    for (const torrent of this.webtorrent.torrents) {
-      if (torrent.address) {
-        try {
-          await this.bothGetPut(torrent)
-        } catch (error) {
-          console.error(error)
-        }
-        await new Promise((resolve, reject) => setTimeout(resolve, 5000))
-      }
-    }
-    this._readyToGo = true
-  }
-
-  // when we resume or seed a user created BEP46 torrent that has already been created before
-  // we have to check that the infohash of the torrent(remember we do not know the infohash before) matches the signature
-  // if it does not match, that means the data/torrent has been corrupted somehow
-  async ownData (address, infoHash) {
-    if (!await fs.pathExists(this._author + path.sep + address)) {
-      throw new Error('data was not found')
-    }
-    // get data from file
-    let data = await fs.readFile(this._author + path.sep + address)
-    // parse the data file
-    data = JSON.parse(data.toString())
-
-    const signatureBuff = Buffer.from(data.sig, 'hex')
-    const encodedSignatureData = encodeSigData({ seq: data.sequence, v: { ih: infoHash, ...data.stuff } })
-    const addressBuff = Buffer.from(data.address, 'hex')
-
-    if (infoHash !== data.infoHash || !ed.verify(signatureBuff, encodedSignatureData, addressBuff)) {
-      throw new Error('data does not match signature')
-    }
-    return data
-  }
-
-  // resolve public key address to an infohash
-  async resolveFunc (address) {
-    if (!address || typeof (address) !== 'string') {
-      throw new Error('address can not be parsed')
-    }
-    const addressKey = Buffer.from(address, 'hex')
-    const getData = await new Promise((resolve, reject) => {
-      sha1(addressKey, (targetID) => {
-        this.webtorrent.dht.get(targetID, (err, res) => {
-          if (err) {
-            reject(err)
-          } else if (res) {
-            resolve(res)
-          } else if (!res) {
-            reject(new Error('Could not resolve address'))
-          }
-        })
-      })
-    })
-    if (!HASH_REGEX.test(getData.v.ih.toString('utf-8')) || !Number.isInteger(getData.seq)) {
-      throw new Error('data is invalid')
-    }
-    for (const prop in getData.v) {
-      getData.v[prop] = getData.v[prop].toString('utf-8')
-    }
-    const { ih, ...stuff } = getData.v
-    return { magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: getData.seq, stuff, sig: getData.sig.toString('hex'), from: getData.id.toString('hex') }
-  }
-
-  // publish an infohash under a public key address in the dht
-  async publishFunc (address, secret, text) {
-    for (const prop in text) {
-      if (typeof (text[prop]) !== 'string') {
-        throw new Error('text data must be strings')
-      }
-    }
-    if (!HASH_REGEX.test(text.ih)) {
-      throw new Error('must have infohash')
-    }
-    if (!address || !secret) {
-      throw new Error('must have address and secret')
-    }
-
-    const buffAddKey = Buffer.from(address, 'hex')
-    const buffSecKey = secret ? Buffer.from(secret, 'hex') : null
-    const v = text
-
-    let main = null
-    let seq = null
-    if (await fs.pathExists(this._author + path.sep + address)) {
-      main = await fs.readFile(this._author + path.sep + address)
-      main = JSON.parse(main.toString())
-      seq = main.sequence + 1
-    } else {
-      seq = 0
-    }
-
-    const buffSig = ed.sign(encodeSigData({ seq, v }), buffAddKey, buffSecKey)
-
-    const putData = await new Promise((resolve, reject) => {
-      this.webtorrent.dht.put({ k: buffAddKey, v, seq, sig: buffSig }, (putErr, hash, number) => {
-        if (putErr) {
-          reject(putErr)
-        } else {
-          resolve({ hash: hash.toString('hex'), number })
-        }
-      })
-    })
-    const { ih, ...stuff } = text
-    main = { magnet: `magnet:?xs=${BTPK_PREFIX}${address}`, address, infoHash: ih, sequence: seq, stuff, sig: buffSig.toString('hex'), ...putData }
-    await fs.writeFile(this._author + path.sep + address, JSON.stringify(main))
-    return main
-  }
-
-  // async shred(address){
-  //     if(await fs.pathExists(this._author + path.sep + address)){
-  //       await fs.remove(this._author + path.sep + address)
-  //       return true
-  //     } else {
-  //       return false
-  //     }
-  //   }
-
-  // we use this function to seed a non-BEP46 torrent that we have already created before, not really needed but here just for consistency
-  async currentHash (hash) {
-    const haveTorrent = this.findTheHash(hash)
-    if (haveTorrent) {
-      return haveTorrent
-    }
-    const folderPath = path.join(this._internal, hash)
-    if (!await fs.pathExists(folderPath)) {
-      throw new Error('folder does not exist')
-    }
-    const checkTorrent = await Promise.race([
-      delayTimeout(this.timeout, new Error(hash + ' took too long, it timed out'), false),
-      new Promise((resolve, reject) => {
-        this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
-          resolve(torrent)
-        })
-      })
-    ])
-    checkTorrent.folder = folderPath
-    checkTorrent.hash = hash
-    return checkTorrent
-  }
-
-  // we must use this function to seed a BEP46 torrent that we have already published before
-  async currentAddress (address) {
-    const haveTorrent = this.findTheAddress(address)
-    if (haveTorrent) {
-      return haveTorrent
-    }
-    const folderPath = path.join(this._internal, address)
-    if (!await fs.pathExists(folderPath)) {
-      throw new Error('folder does not exist')
-    }
-    const checkTorrent = await Promise.race([
-      delayTimeout(this.timeout, new Error(address + ' took too long, it timed out'), false),
-      new Promise((resolve, reject) => {
-        this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
-          resolve(torrent)
-        })
-      })
-    ])
-    const checkProperty = await Promise.race([
-      delayTimeout(this.timeout, new Error(address + ' property took too long, it timed out, please try again with only the keypair without the folder'), false),
-      this.ownData(address, checkTorrent.infoHash)
-    ]).catch(error => {
-      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
-      throw error
-    })
-    // don't overwrite the torrent's infohash even though they will both be the same
-    delete checkProperty.infoHash
-    checkProperty.folder = folderPath
-    for (const prop in checkProperty) {
-      checkTorrent[prop] = checkProperty[prop]
-    }
-    return checkTorrent
-  }
-
-  // download a non-user created BEP46 torrent by their public key address, non-user meaning someone else's BEP46 torrent
-  async loadAddress (address) {
-    const haveTorrent = this.findTheAddress(address)
-    if (haveTorrent) {
-      return haveTorrent
-    }
-    const checkProperty = await Promise.race([
-      delayTimeout(this.timeout, new Error(address + ' property took too long, it timed out'), false),
-      this.resolveFunc(address)
-    ])
-
-    checkProperty.folder = path.join(this._external, checkProperty.address)
-
-    // if current option is true, then if the infohash for the address is brand new then empty the directory and download the new infohash
-    // if the current option is false, then at least make sure the main folder which is named with the public key address exists
-    if (this._current) {
-      if (!await fs.pathExists(checkProperty.folder + path.sep + checkProperty.infoHash)) {
-        await fs.emptyDir(checkProperty.folder)
-      }
-    } else if (!this._current) {
-      if (!await fs.pathExists(checkProperty.folder)) {
-        await fs.ensureDir(checkProperty.folder)
-      }
-    }
-
-    const checkTorrent = await Promise.race([
-      delayTimeout(this.timeout, new Error(checkProperty.address + ' took too long, it timed out'), false),
-      new Promise((resolve, reject) => {
-        this.webtorrent.add(checkProperty.infoHash, { path: checkProperty.folder + path.sep + checkProperty.infoHash, destroyStoreOnDestroy: true }, torrent => {
-          resolve(torrent)
-        })
-      })
-    ])
-    // don't overwrite the torrent's infohash even though they will both be the same
-    delete checkProperty.infoHash
-    for (const prop in checkProperty) {
-      checkTorrent[prop] = checkProperty[prop]
-    }
-    return checkTorrent
-  }
-
-  // publish a new BEP46 torrent, or update an address/public key with a new torrent
-  // we need a folder(string) passed in as an argument
-  // we check we have a torrent already for the public key address
-  // we then copy the data from the folder to the this._internal directory
-  // we return secret key along with the torrent because the user will need it
-  async publishAddress (keypair, headers, data) {
-    if (!keypair || !keypair.address || !keypair.secret) {
-      keypair = this.createKeypair()
-    } else {
-      this.stopAddress(keypair.address)
-    }
-    const folderPath = path.join(this._internal, keypair.address)
-    await fs.ensureDir(folderPath)
-    await this.handleFormData(folderPath, headers, data)
-    const checkFolderPath = await fs.readdir(folderPath, { withFileTypes: false })
-    if (!checkFolderPath.length) {
-      await fs.remove(folderPath)
-      throw new Error('data could not be written to new torrent')
-    }
-    const checkTorrent = await Promise.race([
-      delayTimeout(this.timeout, new Error('torrent took too long, it timed out'), false),
-      new Promise((resolve, reject) => {
-        this.webtorrent.seed(folderPath, { destroyStoreOnDestroy: true }, torrent => {
-          resolve(torrent)
-        })
-      })
-    ])
-    const checkProperty = await Promise.race([
-      delayTimeout(this.timeout, new Error(keypair.address + ' property took too long, it timed out, please try again with only the keypair without the folder'), false),
-      this.publishFunc(keypair.address, keypair.secret, { ih: checkTorrent.infoHash })
-    ]).catch(error => {
-      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
-      throw error
-    })
-    // don't overwrite the torrent's infohash even though they will both be the same
-    delete checkProperty.infoHash
-    checkProperty.folder = folderPath
-    for (const prop in checkProperty) {
-      checkTorrent[prop] = checkProperty[prop]
-    }
-    return { torrent: checkTorrent, secret: keypair.secret }
-  }
-
-  // ------------- the below functions are for stopping or removing data and torrents
-
-  // stops all torrents
-  // clearData () {
-  //   for (let i = 0; i < this.webtorrent.torrents.length; i++) {
-  //     this.webtorrent.remove(this.webtorrent.torrents[i].infoHash, { destroyStore: false })
-  //   }
-  //   return 'data was stopped'
-  // }
-
-  // stops the torrent with the 40 character infohash(string)
-  shredHash (hash) {
-    const checkTorrent = this.findTheHash(hash)
-    if (checkTorrent) {
-      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: true })
-      return true
-    } else {
-      return false
-    }
-  }
-
-  shredAddress (address) {
-    const checkTorrent = this.findTheAddress(address)
-    if (checkTorrent) {
-      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: true })
-      return true
-    } else {
-      return false
-    }
-    // let result = null
-    // const checkTorrent = this.findTheAddress(address)
-    // if (checkTorrent) {
-    //   this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: true })
-    //   result = true
-    // } else {
-    //   if(await fs.pathExists(path.join(this._external, address))){
-    //     await fs.remove(path.join(this._external, address))
-    //     result = true
-    //   }
-    //   if(await fs.pathExists(path.join(this._internal, address))){
-    //     await fs.remove(path.join(this._internal, address))
-    //     result = true
-    //   }
-    // }
-    // return result
-  }
-
-  stopHash (hash) {
-    const checkTorrent = this.findTheHash(hash)
-    if (checkTorrent) {
-      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
-      return hash + ' was stopped'
-    } else {
-      return hash + ' was not found'
-    }
-  }
-
-  // stops the torrent with the 64 character public key(string)
-  stopAddress (address) {
-    const checkTorrent = this.findTheAddress(address)
-    if (checkTorrent) {
-      this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
-      return address + ' was stopped'
-    } else {
-      return address + ' was not found'
-    }
-  }
-
-  // stop the torrent with the infohash, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
-  async removeHash (hash) {
-    const checkTorrent = this.findTheHash(hash)
-    if (!checkTorrent) {
-      throw new Error('could not find ' + hash)
-    }
-    const folder = checkTorrent.folder
-    this.webtorrent.remove(checkTorrent.infoHash, { destroyStore: false })
-    if (folder) {
-      if (await fs.pathExists(folder)) {
-        await fs.remove(folder)
-      }
-    } else {
-      if (await fs.pathExists(path.join(this._external, hash))) {
-        await fs.remove(path.join(this._external, hash))
-      }
-      if (await fs.pathExists(path.join(this._internal, hash))) {
-        await fs.remove(path.join(this._internal, hash))
-      }
-    }
-    return hash + ' was removed'
-  }
-
-  // stop the torrent with the address, then fully remove all data for the torrent, if torrent is not active, then find if we have any data on disk and if we do then delete all that data
-  async removeAddress (address) {
-    const checkedTorrent = this.findTheAddress(address)
-    if (!checkedTorrent) {
-      throw new Error('could not find ' + address)
-    }
-    const folder = checkedTorrent.folder
-    this.webtorrent.remove(checkedTorrent.infoHash, { destroyStore: false })
-    if (folder) {
-      if (await fs.pathExists(folder)) {
-        await fs.remove(folder)
-      }
-    } else {
-      if (await fs.pathExists(path.join(this._external, address))) {
-        await fs.remove(path.join(this._external, address))
-      }
-      if (await fs.pathExists(path.join(this._internal, address))) {
-        await fs.remove(path.join(this._internal, address))
-      }
-      // if (await fs.pathExists(path.join(this._author, address))) {
-      //   await fs.remove(this._author + path.sep + address)
-      // }
-    }
-    return address + ' was removed'
-  }
-
-  // --------------------- the below functions loops and gets the torrents we are seeking, if it is not found then null is returned
-
-  findTheFolder (folder) {
-    let tempTorrent = null
-    for (let i = 0; i < this.webtorrent.torrents.length; i++) {
-      if (this.webtorrent.torrents[i].folder === folder) {
-        tempTorrent = this.webtorrent.torrents[i]
-        break
-      }
-    }
-    return tempTorrent
-  }
-
-  findTheHash (hash) {
-    let tempTorrent = null
-    for (let i = 0; i < this.webtorrent.torrents.length; i++) {
-      if (this.webtorrent.torrents[i].hash === hash) {
-        tempTorrent = this.webtorrent.torrents[i]
-        break
-      }
-    }
-    return tempTorrent
-  }
-
-  findTheAddress (address) {
-    let tempTorrent = null
-    for (let i = 0; i < this.webtorrent.torrents.length; i++) {
-      if (this.webtorrent.torrents[i].address === address) {
-        tempTorrent = this.webtorrent.torrents[i]
-        break
-      }
-    }
-    return tempTorrent
-  }
-
-  // -------------- the below functions are BEP46 helpders, especially bothGetPut which keeps the data active in the dht ----------------
-
-  // this function is used to keep data active in the dht
-  // torrent data is passed in as an argument
-  // it gets the most recent data from another user in the dht
-  // then puts that most recent data back into the dht
-  // if it  can not get the most recent data from another user
-  // then we put the torrent data that we currently have back into the dht
-  bothGetPut (data) {
-    return new Promise((resolve, reject) => {
-      const buffAddKey = Buffer.from(data.address, 'hex')
-      const buffSigData = Buffer.from(data.sig, 'hex')
-      sha1(buffAddKey, (targetID) => {
-        this.webtorrent.dht.get(targetID, (getErr, getData) => {
-          if (getErr) {
-            console.error(getErr)
-          }
-          if (getData) {
-            this.webtorrent.dht.put(getData, (putErr, hash, number) => {
-              if (putErr) {
-                reject(putErr)
-              } else {
-                resolve({ getData, putData: { hash: hash.toString('hex'), number } })
-              }
-            })
-          } else if (!getData) {
-            this.webtorrent.dht.put({ k: buffAddKey, v: { ih: data.infoHash, ...data.stuff }, seq: data.sequence, sig: buffSigData }, (putErr, hash, number) => {
-              if (putErr) {
-                reject(putErr)
-              } else {
-                resolve({ hash: hash.toString('hex'), number })
-              }
-            })
-          }
-        })
-      })
-    })
-  }
-
-  // keep the data we currently hold active by putting it back into the dht
-  keepData (data) {
-    return new Promise((resolve, reject) => {
-      this.webtorrent.dht.put({ k: Buffer.from(data.address, 'hex'), v: { ih: data.infoHash, ...data.stuff }, seq: data.sequence, sig: Buffer.from(data.sig, 'hex') }, (error, hash, number) => {
-        if (error) {
-          reject(error)
-        } else {
-          resolve({ hash: hash.toString('hex'), number })
-        }
-      })
-    })
-  }
-
-  // tries to get the data from another user and put that recent data back into the dht to keep the data active
-  keepCurrent (address) {
-    return new Promise((resolve, reject) => {
-      const buffAddKey = Buffer.from(address, 'hex')
-
-      sha1(buffAddKey, (targetID) => {
-        this.webtorrent.dht.get(targetID, (getErr, getData) => {
-          if (getErr) {
-            reject(getErr)
-          } else if (getData) {
-            this.webtorrent.dht.put(getData, (putErr, hash, number) => {
-              if (putErr) {
-                reject(putErr)
-              } else {
-                resolve({ getData, putData: { hash: hash.toString('hex'), number } })
-              }
-            })
-          } else if (!getData) {
-            reject(new Error('could not find property'))
-          }
-        })
-      })
-    })
   }
 }
 


### PR DESCRIPTION
Supercedes #2 

Not ready to merge yet, but submitting a PR for comments / contrib. Big thanks to @resession for laying down the groundwork!

- [x] `POST` to `bittorrent://$/` to create a new torrent with just the infohash.
  - Can't put files into subfolders due to limitations of `FormData` 🙃
- [x] `POST` to `bittorrent://PETNAME` to derive a public-private keypair from a seed key
  - [x] Update files in root dir
  - [x] Take the `pathname` into account to create subfolders
- [x] `POST` to `bittorrent://PUBLIC_KEY` with `Authorization` header containing `secret`
  - [x] Try to fetch the existing `name` from the torrent if one is not provided. 
  - [ ] If the `name` changes, move the files from the old name to the new name
 - [x] Detect updates to mutable torrents by periodically polling (+re-seeding in the DHT)
   - [ ] Detect when the `name` changes and copy over the files to the new named directory + re-verify the contents