### PR TITLE
chore: drop unused dependenices

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 import makeFetch from 'make-fetch'
 import TorrentManager from './torrent-manager.js'
-import streamToIterator from 'stream-async-iterator'
 import mime from 'mime/lite.js'
 import parseRange from 'range-parser'
 
@@ -11,7 +10,7 @@ const PETNAME_REGEX = /^(?:-|[a-zA-Z0-9]|_)+$/
 export const META_HOSTNAME = 'localhost'
 export const SUPPORTED_METHODS = ['GET', 'POST', 'DELETE', 'HEAD']
 
-export {TorrentManager}
+export { TorrentManager }
 
 export default function makeBTFetch (opts = {}) {
   const torrents = new TorrentManager(opts)
@@ -92,14 +91,14 @@ export default function makeBTFetch (opts = {}) {
                 headers['Content-Length'] = `${length}`
                 headers['Content-Range'] = `bytes ${start}-${end}/${foundFile.length}`
 
-                const data = isHEAD ? [] : streamToIterator(foundFile.createReadStream({ start, end }))
+                const data = isHEAD ? [] : foundFile[Symbol.asyncIterator]({ start, end })
                 return { statusCode: 206, headers, data }
               } else {
-                const data = isHEAD ? [] : streamToIterator(foundFile.createReadStream())
+                const data = isHEAD ? [] : foundFile[Symbol.asyncIterator]()
                 return { statusCode: 200, headers, data }
               }
             } else {
-              const data = isHEAD ? [] : streamToIterator(foundFile.createReadStream())
+              const data = isHEAD ? [] : foundFile[Symbol.asyncIterator]()
               return { statusCode: 200, headers, data }
             }
           } else {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,8 @@
     "make-fetch": "^2.3.1",
     "mime": "^3.0.0",
     "range-parser": "^1.2.1",
-    "simple-sha1": "^3.1.0",
-    "stream-async-iterator": "^2.0.0",
     "tmp-promise": "^3.0.3",
+    "uint8-util": "^2.1.9",
     "webtorrent": "^2.0.34"
   }
 }

--- a/torrent-manager.js
+++ b/torrent-manager.js
@@ -1,14 +1,13 @@
 import WebTorrent from 'webtorrent'
 import fs from 'fs-extra'
 import path from 'path'
-import sha1 from 'simple-sha1'
 import ed from 'ed25519-supercop'
 import derive from 'derive-key'
 import bencode from 'bencode'
 import busboy from 'busboy'
 import { Readable } from 'stream'
 import tmp from 'tmp-promise'
-import crypto from 'crypto'
+import { hash, randomBytes } from 'uint8-util'
 
 const DERIVE_NAMESPACE = 'bittorrent://'
 const ERR_NOT_RESOLVE_ADDRESS = 'Could not resolve address'
@@ -53,7 +52,7 @@ export default class TorrentManager {
     if (fs.existsSync(this.seedKeyFile)) {
       this.seedKey = fs.readFileSync(this.seedKeyFile)
     } else {
-      this.seedKey = crypto.randomBytes(32)
+      this.seedKey = randomBytes(32)
       fs.writeFileSync(this.seedKeyFile, this.seedKey)
     }
 
@@ -428,7 +427,7 @@ export default class TorrentManager {
   async dhtGet (publicKey) {
     try {
       const record = await new Promise((resolve, reject) => {
-        sha1(Buffer.from(publicKey, 'hex'), (targetID) => {
+        hash(Buffer.from(publicKey, 'hex')).then((targetID) => {
           this.webtorrent.dht.get(targetID, (err, res) => {
             if (err) {
               reject(err)


### PR DESCRIPTION
this PR drops some unnecessary dependencies

webtorrent files are async iterable since v2, so you dot need stream-async-iterator

webtorrent no longer uses simple-sha1 so that dependency is dropped

crypto and simple-sha1 is replaced with uint8-util, this is a new module for this package, but webtorrent already imports it so it doesn't actually increase its bundle size